### PR TITLE
Add successful and skipped tests to payload.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,73 +44,137 @@ Sample request
 --------------
 ```json
 {
-          "build":{
-             "artifact":false,
-             "number":35,
-             "reason":"Code has changed",
-             "buildCompletedDate":"2018-12-01T12:36:26.078Z[Zulu]",
-             "testSummary":{
-                "duration":26,
-                "ignoredCount":0,
-                "failedCount":2,
-                "existingFailedCount":1,
-                "quarantineCount":0,
-                "successfulCount":11,
-                "description":"2 of 13 failed",
-                "skippedCount":0,
-                "fixedCount":0,
-                "totalCount":13,
-                "newFailedCount":1
-             },
-             "vcs":[
-                {
-                   "commits":[
-                      {
-                         "comment":"Break stuff.",
-                         "id":"13c43a1e26e5c4635a0ac24e775fed615e069b20"
-                      }
-                   ],
-                   "id":"13c43a1e26e5c4635a0ac24e775fed615e069b20",
-                   "repositoryName":"Assignment"
-                },
-                {
-                   "commits":[
-       
-                   ],
-                   "id":"dcf2dba3846620a89f6c3f63cd9dedfa4336f650",
-                   "repositoryName":"tests"
-                }
-             ],
-             "failedJobs":[
-                {
-                   "failedTests":[
-                      {
-                         "name":"testBubbleSort",
-                         "methodName":"Bubble sort",
-                         "className":"ac1.de.BehaviorTest",
-                         "errors":[
-                            "java.lang.AssertionError: Problem: BubbleSort does not sort correctly expected:<[Mon Feb 15 00:00:00 GMT 2016, Sat Apr 15 00:00:00 GMT 2017, Fri Sep 15 00:00:00 GMT 2017, Thu Nov 08 00:00:00 GMT 2018]> but was:<[Mon Feb 15 00:00:00 GMT 2016, Sat Apr 15 00:00:00 GMT 2017, Thu Nov 08 00:00:00 GMT 2018, Fri Sep 15 00:00:00 GMT 2017]>\n\tat org.junit.Assert.fail(Assert.java:88)\n\tat org.junit.Assert.failNotEquals(Assert.java:834)\n\tat org.junit.Assert.assertEquals(Assert.java:118)\n\tat ac1.de.BehaviorTest.testBubbleSort(BehaviorTest.java:40)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.lang.reflect.Method.invoke(Method.java:498)\n\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)\n\tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n\tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)\n\tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n\tat org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)\n\tat org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)\n\tat java.util.concurrent.FutureTask.run(FutureTask.java:266)\n\tat java.lang.Thread.run(Thread.java:748)\n"
-                         ]
-                      },
-                      {
-                         "name":"testMergeSort",
-                         "methodName":"Merge sort",
-                         "className":"ac1.de.BehaviorTest",
-                         "errors":[
-                            "java.lang.NullPointerException\n\tat java.util.Date.getMillisOf(Date.java:958)\n\tat java.util.Date.compareTo(Date.java:978)\n\tat ac1.de.MergeSort.merge(MergeSort.java:30)\n\tat ac1.de.MergeSort.mergesort(MergeSort.java:19)\n\tat ac1.de.MergeSort.performSort(MergeSort.java:10)\n\tat ac1.de.BehaviorTest.testMergeSort(BehaviorTest.java:46)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.lang.reflect.Method.invoke(Method.java:498)\n\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)\n\tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n\tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)\n\tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n\tat org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)\n\tat org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)\n\tat java.util.concurrent.FutureTask.run(FutureTask.java:266)\n\tat java.lang.Thread.run(Thread.java:748)\n"
-                         ]
-                      }
-                   ],
-                   "id":11403400
-                }
-             ],
-             "successful":false
-          },
-          "secret":"SomeVerySecretToken",
-          "notificationType":"Completed Plan Notification",
-          "plan":{
-             "key":"SC1AC4ASD-BASE"
-          }
-       }
+   "build":{
+      "artifact":false,
+      "number":86,
+      "reason":"Manual build",
+      "buildCompletedDate":"2019-05-05T09:51:30.960Z[Zulu]",
+      "testSummary":{
+         "duration":62,
+         "ignoredCount":0,
+         "failedCount":1,
+         "existingFailedCount":1,
+         "quarantineCount":0,
+         "successfulCount":14,
+         "description":"1 of 15 failed",
+         "skippedCount":0,
+         "fixedCount":0,
+         "totalCount":15,
+         "newFailedCount":0
+      },
+      "vcs":[
+         {
+            "commits":[
+
+            ],
+            "id":"f4158f583a02dc3b9bda47e64749fdbf7e9bdcef",
+            "repositoryName":"Assignment"
+         },
+         {
+            "commits":[
+
+            ],
+            "id":"9be1bb278e08d03ab2519b746702196cead996be",
+            "repositoryName":"tests"
+         }
+      ],
+      "jobs":[
+         {
+            "skippedTests":[
+
+            ],
+            "failedTests":[
+               {
+                  "name":"testBubbleSort",
+                  "methodName":"Bubble sort",
+                  "className":"de.de.SortingExampleBehaviorTest",
+                  "errors":[
+                     "java.lang.AssertionError: Problem: BubbleSort does not sort correctly expected:<[Mon Feb 15 00:00:00 GMT 2016, Sat Apr 15 00:00:00 GMT 2017, Fri Sep 15 00:00:00 GMT 2017, Thu Nov 08 00:00:00 GMT 2018]> but was:<[Thu Nov 08 00:00:00 GMT 2018, Sat Apr 15 00:00:00 GMT 2017, Mon Feb 15 00:00:00 GMT 2016, Fri Sep 15 00:00:00 GMT 2017]>\n\tat org.junit.Assert.fail(Assert.java:88)\n\tat org.junit.Assert.failNotEquals(Assert.java:834)\n\tat org.junit.Assert.assertEquals(Assert.java:118)\n\tat de.de.SortingExampleBehaviorTest.testBubbleSort(SortingExampleBehaviorTest.java:37)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.lang.reflect.Method.invoke(Method.java:498)\n\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)\n\tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n\tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)\n\tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n\tat org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)\n\tat org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)\n\tat java.util.concurrent.FutureTask.run(FutureTask.java:266)\n\tat java.lang.Thread.run(Thread.java:748)\n"
+                  ]
+               }
+            ],
+            "successfulTests":[
+               {
+                  "name":"testUseBubbleSortForSmallList",
+                  "methodName":"Use bubble sort for small list",
+                  "className":"de.de.SortingExampleBehaviorTest"
+               },
+               {
+                  "name":"testConstructors[Policy]",
+                  "methodName":"Constructors[policy]",
+                  "className":"de.de.ConstructorTest"
+               },
+               {
+                  "name":"testClass[Policy]",
+                  "methodName":"Class[policy]",
+                  "className":"de.de.ClassTest"
+               },
+               {
+                  "name":"testClass[Context]",
+                  "methodName":"Class[context]",
+                  "className":"de.de.ClassTest"
+               },
+               {
+                  "name":"testMethods[SortStrategy]",
+                  "methodName":"Methods[sort strategy]",
+                  "className":"de.de.MethodTest"
+               },
+               {
+                  "name":"testMethods[Policy]",
+                  "methodName":"Methods[policy]",
+                  "className":"de.de.MethodTest"
+               },
+               {
+                  "name":"testClass[BubbleSort]",
+                  "methodName":"Class[bubble sort]",
+                  "className":"de.de.ClassTest"
+               },
+               {
+                  "name":"testMergeSort",
+                  "methodName":"Merge sort",
+                  "className":"de.de.SortingExampleBehaviorTest"
+               },
+               {
+                  "name":"testAttributes[Context]",
+                  "methodName":"Attributes[context]",
+                  "className":"de.de.AttributeTest"
+               },
+               {
+                  "name":"testUseMergeSortForBigList",
+                  "methodName":"Use merge sort for big list",
+                  "className":"de.de.SortingExampleBehaviorTest"
+               },
+               {
+                  "name":"testAttributes[Policy]",
+                  "methodName":"Attributes[policy]",
+                  "className":"de.de.AttributeTest"
+               },
+               {
+                  "name":"testMethods[Context]",
+                  "methodName":"Methods[context]",
+                  "className":"de.de.MethodTest"
+               },
+               {
+                  "name":"testClass[SortStrategy]",
+                  "methodName":"Class[sort strategy]",
+                  "className":"de.de.ClassTest"
+               },
+               {
+                  "name":"testClass[MergeSort]",
+                  "methodName":"Class[merge sort]",
+                  "className":"de.de.ClassTest"
+               }
+            ],
+            "id":14581874
+         }
+      ],
+      "successful":false
+   },
+   "secret":"SomeVerySecretToken",
+   "notificationType":"Completed Plan Notification",
+   "plan":{
+      "key":"CO1BRD3-SOLUTION"
+   }
+}
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <description>Notify a Server when a build was executed.</description>
     <packaging>atlassian-plugin</packaging>
     <properties>
-        <bamboo.version>5.9.10</bamboo.version>
+        <bamboo.version>6.8.1</bamboo.version>
         <bamboo.data.version>${bamboo.version}</bamboo.data.version>
         <amps.version>6.3.21</amps.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>

--- a/src/main/java/de/tum/in/www1/bamboo/server/BuildCompleteListener.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/BuildCompleteListener.java
@@ -1,0 +1,20 @@
+package de.tum.in.www1.bamboo.server;
+
+import com.atlassian.bamboo.v2.build.CurrentBuildResult;
+import com.atlassian.bamboo.v2.build.events.PostBuildCompletedEvent;
+import com.atlassian.event.api.EventListener;
+
+public class BuildCompleteListener {
+
+    @EventListener
+    public void onPostBuildComplete(final PostBuildCompletedEvent postBuildCompletedEvent) {
+        CurrentBuildResult currentBuildResult = postBuildCompletedEvent.getContext().getBuildResult();
+
+        TestResultsContainer testResultsContainer = new TestResultsContainer(postBuildCompletedEvent.getPlanResultKey(), currentBuildResult.getSuccessfulTestResults(), currentBuildResult.getSkippedTestResults(), currentBuildResult.getFailedTestResults());
+        ServerNotificationRecipient.getCachedTestResults().put(postBuildCompletedEvent.getPlanResultKey().toString(), testResultsContainer);
+
+        // Remove old TestResultsContainer based on their initialization timestamp
+        ServerNotificationRecipient.clearOldTestResultsContainer();
+    }
+
+}

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationRecipient.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationRecipient.java
@@ -17,9 +17,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ServerNotificationRecipient extends AbstractNotificationRecipient implements DeploymentResultAwareNotificationRecipient,
                                                                                            NotificationRecipient.RequiresPlan,
@@ -50,7 +50,7 @@ public class ServerNotificationRecipient extends AbstractNotificationRecipient i
      * Notifications enabled.
      * The time (in seconds) after the TestResultsContainer can be specified in the variable TESTRESULTSCONTAINER_REMOVE_TIME.
      */
-    private static Map<String, TestResultsContainer> cachedTestResults = new HashMap<>();
+    private static Map<String, TestResultsContainer> cachedTestResults = new ConcurrentHashMap<>();
 
     @Override
     public void populate(@NotNull Map<String, String[]> params)

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -220,6 +220,9 @@ public class ServerNotificationTransport implements NotificationTransport
                         }
                     }
                     buildDetails.put("jobs", jobs);
+
+                    // TODO: This ensures outdated versions of Artemis can still process the new request. Will be removed without further notice in the future
+                    buildDetails.put("failedJobs", jobs);
                 }
 
                 jsonObject.put("build", buildDetails);

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -1,14 +1,15 @@
 package de.tum.in.www1.bamboo.server;
 
 import com.atlassian.bamboo.chains.ChainResultsSummary;
+import com.atlassian.bamboo.chains.ChainStageResult;
 import com.atlassian.bamboo.commit.Commit;
 import com.atlassian.bamboo.deployments.results.DeploymentResult;
 import com.atlassian.bamboo.notification.Notification;
 import com.atlassian.bamboo.notification.NotificationTransport;
 import com.atlassian.bamboo.plan.cache.ImmutablePlan;
+import com.atlassian.bamboo.results.tests.TestResults;
 import com.atlassian.bamboo.resultsummary.BuildResultsSummary;
 import com.atlassian.bamboo.resultsummary.ResultsSummary;
-import com.atlassian.bamboo.resultsummary.tests.TestCaseResult;
 import com.atlassian.bamboo.resultsummary.tests.TestCaseResultError;
 import com.atlassian.bamboo.resultsummary.tests.TestResultsSummary;
 import com.atlassian.bamboo.resultsummary.vcs.RepositoryChangeset;
@@ -17,7 +18,6 @@ import com.atlassian.bamboo.variable.CustomVariableContext;
 import com.atlassian.bamboo.variable.VariableDefinition;
 import com.atlassian.bamboo.variable.VariableDefinitionManager;
 import com.atlassian.spring.container.ContainerManager;
-import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -31,7 +31,6 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -39,6 +38,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Collection;
 
 public class ServerNotificationTransport implements NotificationTransport
 {
@@ -116,7 +116,7 @@ public class ServerNotificationTransport implements NotificationTransport
                 log.debug(method.getEntity().toString());
                 client.execute(method);
             } catch (IOException e) {
-                log.error("Error using Slack API: " + e.getMessage(), e);
+                log.error("Error while sending payload: " + e.getMessage(), e);
             }
         }
         catch(URISyntaxException e)
@@ -197,41 +197,32 @@ public class ServerNotificationTransport implements NotificationTransport
 
                 if (resultsSummary instanceof ChainResultsSummary) {
                     ChainResultsSummary chainResultsSummary = (ChainResultsSummary) resultsSummary;
+                    JSONArray jobs = new JSONArray();
+                    for (ChainStageResult chainStageResult : chainResultsSummary.getStageResults()) {
+                        for (BuildResultsSummary buildResultsSummary : chainStageResult.getBuildResults()) {
 
-                    JSONArray failedJobs = new JSONArray();
-                    for (BuildResultsSummary failedJob : chainResultsSummary.getFailedJobResults()) {
-                        JSONObject failedJobDetails = new JSONObject();
+                            JSONObject jobDetails = new JSONObject();
 
-                        failedJobDetails.put("id", failedJob.getId());
+                            jobDetails.put("id", buildResultsSummary.getId());
 
-                        JSONArray testDetails = new JSONArray();
+                            TestResultsContainer testResultsContainer = ServerNotificationRecipient.getCachedTestResults().get(buildResultsSummary.getPlanResultKey().toString());
+                            if (testResultsContainer != null) {
+                                JSONArray successfulTestDetails = createTestsResultsJSONArray(testResultsContainer.getSuccessfulTests(), false);
+                                jobDetails.put("successfulTests", successfulTestDetails);
 
-                        for (TestCaseResult testCaseResult : failedJob.getFilteredTestResults().getAllFailedTestList()) {
-                            JSONObject testCaseDetails = new JSONObject();
-                            testCaseDetails.put("name", testCaseResult.getName());
-                            testCaseDetails.put("methodName", testCaseResult.getMethodName());
-                            testCaseDetails.put("className", testCaseResult.getTestCase().getTestClass().getName());
+                                JSONArray skippedTestDetails = createTestsResultsJSONArray(testResultsContainer.getSkippedTests(), false);
+                                jobDetails.put("skippedTests", skippedTestDetails);
 
-                            JSONArray testCaseErrorDetails = new JSONArray();
-                            for(TestCaseResultError testCaseResultError : testCaseResult.getErrors()) {
-                                testCaseErrorDetails.put(testCaseResultError.getContent());
+                                JSONArray failedTestDetails = createTestsResultsJSONArray(testResultsContainer.getFailedTests(), true);
+                                jobDetails.put("failedTests", failedTestDetails);
                             }
-
-                            testCaseDetails.put("errors", testCaseErrorDetails);
-
-                            testDetails.put(testCaseDetails);
+                            jobs.put(jobDetails);
                         }
-
-                        failedJobDetails.put("failedTests", testDetails);
-
-                        failedJobs.put(failedJobDetails);
                     }
-
-                    buildDetails.put("failedJobs", failedJobs);
+                    buildDetails.put("jobs", jobs);
                 }
 
                 jsonObject.put("build", buildDetails);
-
             }
 
 
@@ -240,5 +231,31 @@ public class ServerNotificationTransport implements NotificationTransport
         }
 
         return  jsonObject;
+    }
+
+    private JSONObject createTestsResultsJSONObject(TestResults testResults, boolean addErrors) throws JSONException {
+        JSONObject testResultsJSON = new JSONObject();
+        testResultsJSON.put("name", testResults.getActualMethodName());
+        testResultsJSON.put("methodName", testResults.getMethodName());
+        testResultsJSON.put("className", testResults.getClassName());
+
+        if (addErrors) {
+            JSONArray testCaseErrorDetails = new JSONArray();
+            for(TestCaseResultError testCaseResultError : testResults.getErrors()) {
+                testCaseErrorDetails.put(testCaseResultError.getContent());
+            }
+            testResultsJSON.put("errors", testCaseErrorDetails);
+        }
+
+        return testResultsJSON;
+    }
+
+    private JSONArray createTestsResultsJSONArray(Collection<TestResults> testResultsCollection, boolean addErrors) throws JSONException {
+        JSONArray testResultsArray = new JSONArray();
+        for (TestResults testResults : testResultsCollection) {
+            testResultsArray.put(createTestsResultsJSONObject(testResults, addErrors));
+        }
+
+        return testResultsArray;
     }
 }

--- a/src/main/java/de/tum/in/www1/bamboo/server/TestResultsContainer.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/TestResultsContainer.java
@@ -1,0 +1,61 @@
+package de.tum.in.www1.bamboo.server;
+
+import com.atlassian.bamboo.plan.PlanKey;
+import com.atlassian.bamboo.plan.PlanResultKey;
+import com.atlassian.bamboo.results.tests.TestResults;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class TestResultsContainer {
+
+    private final PlanResultKey planResultKey;
+    private final long initTimestamp = System.currentTimeMillis();
+
+    private Collection<TestResults> successfulTests = new ArrayList<>();
+    private Collection<TestResults> skippedTests = new ArrayList<>();
+    private Collection<TestResults> failedTests = new ArrayList<>();
+
+    public TestResultsContainer(PlanResultKey planResultKey) {
+        this.planResultKey = planResultKey;
+    }
+
+    public TestResultsContainer(PlanResultKey planResultKey, Collection<TestResults> successfulTests, Collection<TestResults> skippedTests, Collection<TestResults> failedTests) {
+        this.planResultKey = planResultKey;
+        this.successfulTests = successfulTests;
+        this.skippedTests = skippedTests;
+        this.failedTests = failedTests;
+    }
+
+    public PlanResultKey getPlanResultKey() {
+        return planResultKey;
+    }
+
+    public long getInitTimestamp() {
+        return initTimestamp;
+    }
+
+    public Collection<TestResults> getSuccessfulTests() {
+        return successfulTests;
+    }
+
+    public Collection<TestResults> getSkippedTests() {
+        return skippedTests;
+    }
+
+    public Collection<TestResults> getFailedTests() {
+        return failedTests;
+    }
+
+    @Override
+    public String toString() {
+        return "TestResultsContainer{" +
+                "planResultKey=" + planResultKey +
+                ", initTimestamp=" + initTimestamp +
+                ", successfulTests=" + successfulTests +
+                ", skippedTests=" + skippedTests +
+                ", failedTests=" + failedTests +
+                '}';
+    }
+}

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -19,4 +19,7 @@
     <component-import key="variableDefinitionManager">
         <interface>com.atlassian.bamboo.variable.VariableDefinitionManager</interface>
     </component-import>
+
+    <bambooEventListener key="buildCompleteListener"
+                         class="de.tum.in.www1.bamboo.server.BuildCompleteListener"/>
 </atlassian-plugin>


### PR DESCRIPTION
This PR adds a BuildCompleteListener that listens on the PostBuildCompletedEvent. The testcases provided in the BuildContext get saved into a Map and can be accessed from the ChainCompletedNotification.
See the comment above the Map cachedTestResults in the class ServerNotificationRecipient for more information.

Updated Bamboo-api-version.

Updated sample payload shown on README.