### PR TITLE
Add build log to payload.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ sudo: false
 
 language: java
 
+env:
+  global:
+    - JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.2
+
 branches:
   except:
   - /^v[0-9]*/

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Feedback? Questions?
 
 Email: krusche@in.tum.de
 
+Debug
+-----
+
+You can reach the debug log under `<bamboo-host>/chain/viewChainActivityLog.action?planKey=XXX`.
 
 Sample request
 --------------

--- a/README.md
+++ b/README.md
@@ -214,7 +214,44 @@ Sample request
                   ]
                }
             ],
-            "logs": [],
+            "logs": [
+               {
+                  "date":"Wed Aug 26 09:00:22 GMT 2020",
+                  "log":"[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project BSN-2-Tests: Compilation failure"
+               },
+               {
+                  "date":"Wed Aug 26 09:00:22 GMT 2020",
+                  "log":"[ERROR] /home/bamboo/bamboo-agent-home/xml-data/build-dir/BSNBSN2-ADMIN-JOB1/assignment/src/de/tum/in/ase/BubbleSort.java:[9,2] ';' expected"
+               },
+               {
+                  "date":"Wed Aug 26 09:00:22 GMT 2020",
+                  "log":"[ERROR] -&gt; [Help 1]"
+               },
+               {
+                  "date":"Wed Aug 26 09:00:22 GMT 2020",
+                  "log":"[ERROR] "
+               },
+               {
+                  "date":"Wed Aug 26 09:00:22 GMT 2020",
+                  "log":"[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch."
+               },
+               {
+                  "date":"Wed Aug 26 09:00:22 GMT 2020",
+                  "log":"[ERROR] Re-run Maven using the -X switch to enable full debug logging."
+               },
+               {
+                  "date":"Wed Aug 26 09:00:22 GMT 2020",
+                  "log":"[ERROR] "
+               },
+               {
+                  "date":"Wed Aug 26 09:00:22 GMT 2020",
+                  "log":"[ERROR] For more information about the errors and possible solutions, please read the following articles:"
+               },
+               {
+                  "date":"Wed Aug 26 09:00:22 GMT 2020",
+                  "log":"[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException"
+               }
+            ],
             "id":14581874
          }
       ],

--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ Sample request
                   "className":"de.de.ClassTest"
                }
             ],
-            "id":14581874
+            "id":14581874,
+            "logs": []
          }
       ],
       "successful":false

--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ Sample request
                   ]
                }
             ],
-            "logs": []
-            "id":14581874,
+            "logs": [],
+            "id":14581874
          }
       ],
       "successful":false

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,16 @@
     <repositories>
         <repository>
             <id>atlassian-public</id>
-            <url>https://maven.atlassian.com/content/repositories/atlassian-public/</url>
+            <url>https://packages.atlassian.com/mvn/maven-external/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+                <checksumPolicy>warn</checksumPolicy>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+                <checksumPolicy>warn</checksumPolicy>
+            </releases>
         </repository>
     </repositories>
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.tum.in.www1</groupId>
     <artifactId>bamboo-server</artifactId>
-    <version>1.1.5</version>
+    <version>1.2.0</version>
     <organization>
         <name>LS1 TUM</name>
         <url>http://www1.in.tum.de/</url>
@@ -23,7 +23,7 @@
     <description>Notify a Server when a build was executed.</description>
     <packaging>atlassian-plugin</packaging>
     <properties>
-        <bamboo.version>6.8.1</bamboo.version>
+        <bamboo.version>7.0.2</bamboo.version>
         <bamboo.data.version>${bamboo.version}</bamboo.data.version>
         <amps.version>6.3.21</amps.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.tum.in.www1</groupId>
     <artifactId>bamboo-server</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.5</version>
     <organization>
         <name>LS1 TUM</name>
         <url>http://www1.in.tum.de/</url>

--- a/src/main/java/de/tum/in/www1/bamboo/server/BuildCompleteListener.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/BuildCompleteListener.java
@@ -4,15 +4,17 @@ import com.atlassian.bamboo.v2.build.CurrentBuildResult;
 import com.atlassian.bamboo.v2.build.events.PostBuildCompletedEvent;
 import com.atlassian.event.api.EventListener;
 
+import java.util.Collections;
+
 public class BuildCompleteListener {
 
     @EventListener
     public void onPostBuildComplete(final PostBuildCompletedEvent postBuildCompletedEvent) {
         CurrentBuildResult currentBuildResult = postBuildCompletedEvent.getContext().getBuildResult();
         TestResultsContainer testResultsContainer = new TestResultsContainer(postBuildCompletedEvent.getPlanResultKey(),
-                currentBuildResult.getSuccessfulTestResults(),
-                currentBuildResult.getSkippedTestResults(),
-                currentBuildResult.getFailedTestResults());
+                currentBuildResult.getSuccessfulTestResults() != null ? currentBuildResult.getSuccessfulTestResults() : Collections.emptySet(),
+                currentBuildResult.getSkippedTestResults() != null ? currentBuildResult.getSkippedTestResults() : Collections.emptySet(),
+                currentBuildResult.getFailedTestResults() != null ? currentBuildResult.getFailedTestResults() : Collections.emptySet());
         ServerNotificationRecipient.getCachedTestResults().put(postBuildCompletedEvent.getPlanResultKey().toString(), testResultsContainer);
 
         // Remove old TestResultsContainer based on their initialization timestamp

--- a/src/main/java/de/tum/in/www1/bamboo/server/BuildCompleteListener.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/BuildCompleteListener.java
@@ -14,8 +14,8 @@ public class BuildCompleteListener {
         ResultsContainer resultsContainer = new ResultsContainer(postBuildCompletedEvent.getPlanResultKey(),
                 currentBuildResult.getSuccessfulTestResults() != null ? currentBuildResult.getSuccessfulTestResults() : Collections.emptySet(),
                 currentBuildResult.getSkippedTestResults() != null ? currentBuildResult.getSkippedTestResults() : Collections.emptySet(),
-                currentBuildResult.getFailedTestResults() != null ? currentBuildResult.getFailedTestResults() : Collections.emptySet()
-                currentBuildResult.getTaskResults() != null ? currentBuildResult.getTaskResults : Collections.emptySet());
+                currentBuildResult.getFailedTestResults() != null ? currentBuildResult.getFailedTestResults() : Collections.emptySet(),
+                currentBuildResult.getTaskResults());
         ServerNotificationRecipient.getCachedTestResults().put(postBuildCompletedEvent.getPlanResultKey().toString(), resultsContainer);
 
         // Remove old ResultsContainer based on their initialization timestamp

--- a/src/main/java/de/tum/in/www1/bamboo/server/BuildCompleteListener.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/BuildCompleteListener.java
@@ -9,8 +9,10 @@ public class BuildCompleteListener {
     @EventListener
     public void onPostBuildComplete(final PostBuildCompletedEvent postBuildCompletedEvent) {
         CurrentBuildResult currentBuildResult = postBuildCompletedEvent.getContext().getBuildResult();
-
-        TestResultsContainer testResultsContainer = new TestResultsContainer(postBuildCompletedEvent.getPlanResultKey(), currentBuildResult.getSuccessfulTestResults(), currentBuildResult.getSkippedTestResults(), currentBuildResult.getFailedTestResults());
+        TestResultsContainer testResultsContainer = new TestResultsContainer(postBuildCompletedEvent.getPlanResultKey(),
+                currentBuildResult.getSuccessfulTestResults(),
+                currentBuildResult.getSkippedTestResults(),
+                currentBuildResult.getFailedTestResults());
         ServerNotificationRecipient.getCachedTestResults().put(postBuildCompletedEvent.getPlanResultKey().toString(), testResultsContainer);
 
         // Remove old TestResultsContainer based on their initialization timestamp

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationRecipient.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationRecipient.java
@@ -181,7 +181,7 @@ public class ServerNotificationRecipient extends AbstractNotificationRecipient i
         return buildLogFileAccessorFactory;
     }
 
-    public static Map<String, TestResultsContainer> getCachedTestResults() {
+    public static Map<String, ResultsContainer> getCachedTestResults() {
         return cachedTestResults;
     }
 

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationRecipient.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationRecipient.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.bamboo.server;
 
 import com.atlassian.bamboo.build.BuildLoggerManager;
+import com.atlassian.bamboo.build.logger.BuildLogFileAccessorFactory;
 import com.atlassian.bamboo.deployments.results.DeploymentResult;
 import com.atlassian.bamboo.notification.NotificationRecipient;
 import com.atlassian.bamboo.notification.NotificationTransport;
@@ -10,6 +11,7 @@ import com.atlassian.bamboo.plan.Plan;
 import com.atlassian.bamboo.plan.cache.ImmutablePlan;
 import com.atlassian.bamboo.plugin.descriptor.NotificationRecipientModuleDescriptor;
 import com.atlassian.bamboo.resultsummary.ResultsSummary;
+import com.atlassian.bamboo.storage.StorageLocationService;
 import com.atlassian.bamboo.template.TemplateRenderer;
 import com.atlassian.bamboo.variable.CustomVariableContext;
 import com.google.common.collect.Lists;
@@ -38,6 +40,7 @@ public class ServerNotificationRecipient extends AbstractNotificationRecipient i
     private DeploymentResult deploymentResult;
     private CustomVariableContext customVariableContext;
     private static BuildLoggerManager buildLoggerManager;
+    private static BuildLogFileAccessorFactory buildLogFileAccessorFactory;
 
     // Time in seconds before removing TestResultsContainer
     private static final int TESTRESULTSCONTAINER_REMOVE_TIME = 60;
@@ -134,7 +137,7 @@ public class ServerNotificationRecipient extends AbstractNotificationRecipient i
     public List<NotificationTransport> getTransports()
     {
         List<NotificationTransport> list = Lists.newArrayList();
-        list.add(new ServerNotificationTransport(webhookUrl, plan, resultsSummary, deploymentResult, customVariableContext, buildLoggerManager));
+        list.add(new ServerNotificationTransport(webhookUrl, plan, resultsSummary, deploymentResult, customVariableContext, buildLoggerManager, buildLogFileAccessorFactory));
         return list;
     }
 
@@ -166,6 +169,16 @@ public class ServerNotificationRecipient extends AbstractNotificationRecipient i
     public static BuildLoggerManager getBuildLoggerManager()
     {
         return buildLoggerManager;
+    }
+
+    public void setBuildLogFileAccessorFactory(@Nullable final BuildLogFileAccessorFactory buildLogFileAccessorFactory)
+    {
+        this.buildLogFileAccessorFactory = buildLogFileAccessorFactory;
+    }
+
+    public static BuildLogFileAccessorFactory getBuildLogFileAccessorFactory()
+    {
+        return buildLogFileAccessorFactory;
     }
 
     public static Map<String, TestResultsContainer> getCachedTestResults() {

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -294,7 +294,7 @@ public class ServerNotificationTransport implements NotificationTransport
                                 // A lambda here would require us to catch the JSONException inside the lambda, so we use a loop.
                                 logEntriesArray.put(createLogEntryJSONObject(logEntry));
                             }
-                            jobDetails.put("log", logEntriesArray); // We add an empty array here in case tests are found to prevent errors while parsing in the client
+                            jobDetails.put("logs", logEntriesArray); // We add an empty array here in case tests are found to prevent errors while parsing in the client
 
                             jobs.put(jobDetails);
                         }

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -95,7 +95,7 @@ public class ServerNotificationTransport implements NotificationTransport
     private static int FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS = 5000;
 
     // Maximum number of lines of log per job. The last lines will be taken.
-    private static int JOB_LOG_MAX_LINES = 250;
+    private static int JOB_LOG_MAX_LINES = 1000;
 
     // We are only interested in logs coming from the build, not in logs from Bamboo
     final List<Class<?>> logEntryTypes = ImmutableList.of(BuildOutputLogEntry.class, ErrorLogEntry.class);

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -22,6 +22,8 @@
 
     <component-import key="buildLoggerManager" interface="com.atlassian.bamboo.build.BuildLoggerManager"/>
 
+    <component-import key="buildLogFileAccessorFactory" interface="com.atlassian.bamboo.build.logger.BuildLogFileAccessorFactory"/>
+
     <bambooEventListener key="buildCompleteListener"
                          class="de.tum.in.www1.bamboo.server.BuildCompleteListener"/>
 </atlassian-plugin>


### PR DESCRIPTION
This PR adds the build log to the payload that is sent to the remote endpoint.


The 250 last lines of the build log are added to the payload if no tests are detected by Bamboo (indicating a build failure).
If some tests are detected (regardless if they are passed or not), the build log is not included as the build compiled successfully.