### PR TITLE
Add error log messages if SERVER_PLUGIN_SECRET_PASSWORD variable is not set.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.tum.in.www1</groupId>
     <artifactId>bamboo-server</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <organization>
         <name>LS1 TUM</name>
         <url>http://www1.in.tum.de/</url>


### PR DESCRIPTION
Show error messages in the log if the `SERVER_PLUGIN_SECRET_PASSWORD` is not set.

Also set the secret to a string explaining the error message.