### PR TITLE
Checkstyle and PMD report parsing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 <!-- If your pull request is not ready for review yet, create a draft pull request! -->
 
 ### Checklist
-- [ ] I built and deployed the plugin locally and tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) locally.
+- [ ] I built and deployed the plugin locally and tested *all* changes and *all* related features.
 - [ ] I documented the Java code using JavaDoc style.
 
 ### Motivation and Context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!-- Thanks for contributing to the Bamboo Server Notification Plugin! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
+<!-- If your pull request is not ready for review yet, create a draft pull request! -->
+
+### Checklist
+- [ ] I built and deployed the plugin locally and tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) locally.
+- [ ] I documented the Java code using JavaDoc style.
+
+### Motivation and Context
+<!-- Why is this change required? What problem does it solve? -->
+<!-- If it fixes an open issue, please link to the issue here. -->
+
+### Description
+<!-- Describe your changes in detail -->
+
+### Steps for Testing
+<!-- Please describe in detail how the reviewer can test your changes. -->
+
+1. Deploy the plugin on a local Bamboo installation
+2. ...

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Sample request
                      {
                          "file":"com/ls1/staticCodeAnalysis/App.java",
                          "startLine":16,
+                         "endLine":16,
                          "rule":"ES_COMPARING_PARAMETER_STRING_WITH_EQ",
                          "category":"BAD_PRACTICE",
                          "message":"Comparison of String parameter using == or != in com.stefan.staticCodeAnalysis.App.equalString(String)",
@@ -219,7 +220,9 @@ Sample request
                      {
                          "file":"com/ls1/staticCodeAnalysis/App.java",
                          "startLine":7,
+                         "endLine":7,
                          "startColumn":1,
+                         "endColumn":1,
                          "rule":"HideUtilityClassConstructorCheck",
                          "category":"design",
                          "message":"Utility classes should not have a public or default constructor.",

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Sample request
                   "state":"FAILED"
                }           
             ],
-            "staticAssessmentReports":[
+            "staticCodeAnalysisReports":[
                {
                   "tool":"SPOTBUGS",
                   "issues":[
@@ -243,7 +243,6 @@ Sample request
                      }
                   ]
                }
-           
             ],
             "logs": [
                {

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Sample request
                   "tool":"SPOTBUGS",
                   "issues":[
                      {
-                         "file":"com/ls1/staticCodeAnalysis/App.java",
+                         "filePath":"com/ls1/staticCodeAnalysis/App.java",
                          "startLine":16,
                          "endLine":16,
                          "rule":"ES_COMPARING_PARAMETER_STRING_WITH_EQ",
@@ -218,7 +218,7 @@ Sample request
                   "tool":"CHECKSTYLE",
                   "issues":[
                      {
-                         "file":"com/ls1/staticCodeAnalysis/App.java",
+                         "filePath":"com/ls1/staticCodeAnalysis/App.java",
                          "startLine":7,
                          "endLine":7,
                          "startColumn":1,
@@ -234,7 +234,7 @@ Sample request
                   "tool":"PMD",
                   "issues":[
                      {
-                         "file":"com/ls1/staticCodeAnalysis/App.java",
+                         "filePath":"com/ls1/staticCodeAnalysis/App.java",
                          "startLine":10,
                          "endLine":10,
                          "startColumn":16,

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Sample request
                   "tool":"SPOTBUGS",
                   "issues":[
                      {
-                         "filePath":"com/ls1/staticCodeAnalysis/App.java",
+                         "filePath":"/buildDir/testExercise/assignment/src/com/ls1/staticCodeAnalysis/App.java",
                          "startLine":16,
                          "endLine":16,
                          "rule":"ES_COMPARING_PARAMETER_STRING_WITH_EQ",
@@ -218,7 +218,7 @@ Sample request
                   "tool":"CHECKSTYLE",
                   "issues":[
                      {
-                         "filePath":"com/ls1/staticCodeAnalysis/App.java",
+                         "filePath":"/buildDir/testExercise/assignment/src/com/ls1/staticCodeAnalysis/App.java",
                          "startLine":7,
                          "endLine":7,
                          "startColumn":1,
@@ -234,7 +234,7 @@ Sample request
                   "tool":"PMD",
                   "issues":[
                      {
-                         "filePath":"com/ls1/staticCodeAnalysis/App.java",
+                         "filePath":"/buildDir/testExercise/assignment/src/com/ls1/staticCodeAnalysis/App.java",
                          "startLine":10,
                          "endLine":10,
                          "startColumn":16,

--- a/README.md
+++ b/README.md
@@ -204,15 +204,46 @@ Sample request
                   "tool":"SPOTBUGS",
                   "issues":[
                      {
-                         "classname":"com.stefan.staticCodeAnalysis.App",
-                         "type":"ES_COMPARING_PARAMETER_STRING_WITH_EQ",
-                         "priority":"High",
+                         "file":"com/ls1/staticCodeAnalysis/App.java",
+                         "startLine":16,
+                         "rule":"ES_COMPARING_PARAMETER_STRING_WITH_EQ",
                          "category":"BAD_PRACTICE",
                          "message":"Comparison of String parameter using == or != in com.stefan.staticCodeAnalysis.App.equalString(String)",
-                         "line":16
+                         "priority":"1"
+                     }
+                  ]
+               },
+               {
+                  "tool":"CHECKSTYLE",
+                  "issues":[
+                     {
+                         "file":"com/ls1/staticCodeAnalysis/App.java",
+                         "startLine":7,
+                         "startColumn":1,
+                         "rule":"HideUtilityClassConstructorCheck",
+                         "category":"design",
+                         "message":"Utility classes should not have a public or default constructor.",
+                         "priority":"error"
+                     }
+                  ]
+               },
+               {
+                  "tool":"PMD",
+                  "issues":[
+                     {
+                         "file":"com/ls1/staticCodeAnalysis/App.java",
+                         "startLine":10,
+                         "endLine":10,
+                         "startColumn":16,
+                         "endColumn":16,
+                         "rule":"UnusedLocalVariable",
+                         "category":"Best Practices",
+                         "message":"Avoid unused local variables such as 'b'.",
+                         "priority":"3"
                      }
                   ]
                }
+           
             ],
             "logs": [
                {

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,11 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.1</version>
         </dependency>
+        <dependency>
+            <groupId>xom</groupId>
+            <artifactId>xom</artifactId>
+            <version>1.3.5</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.tum.in.www1</groupId>
     <artifactId>bamboo-server</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <organization>
         <name>LS1 TUM</name>
         <url>http://www1.in.tum.de/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,21 @@
             <version>1.8.2</version>
         </dependency>
         <dependency>
+            <groupId>xom</groupId>
+            <artifactId>xom</artifactId>
+            <version>1.3.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.1</version>
@@ -137,6 +152,11 @@
                     <productVersion>${bamboo.version}</productVersion>
                     <productDataVersion>${bamboo.data.version}</productDataVersion>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.tum.in.www1</groupId>
     <artifactId>bamboo-server</artifactId>
-    <version>1.3</version>
+    <version>1.3.0</version>
     <organization>
         <name>LS1 TUM</name>
         <url>http://www1.in.tum.de/</url>

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -311,8 +311,8 @@ public class ServerNotificationTransport implements NotificationTransport
                                 logErrorToBuildLog("Could not load cached test results!");
                             }
                             logToBuildLog("Loading artifacts for job " + buildResultsSummary.getId());
-                            JSONArray staticAssessmentReports = createStaticCodeAnalysisReportArray(buildResultsSummary.getProducedArtifactLinks(), buildResultsSummary.getId());
-                            jobDetails.put("staticCodeAnalysisReports", staticAssessmentReports);
+                            JSONArray staticCodeAnalysisReports = createStaticCodeAnalysisReportArray(buildResultsSummary.getProducedArtifactLinks(), buildResultsSummary.getId());
+                            jobDetails.put("staticCodeAnalysisReports", staticCodeAnalysisReports);
 
 
                             List<LogEntry> logEntries = Collections.emptyList();

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -84,6 +84,8 @@ public class ServerNotificationTransport implements NotificationTransport
     private final DeploymentResult deploymentResult;
     @Nullable
     private final BuildLoggerManager buildLoggerManager;
+    @Nullable
+    private final BuildLogFileAccessorFactory buildLogFileAccessorFactory;
 
     // Will be injected by Bamboo
     private VariableDefinitionManager variableDefinitionManager = (VariableDefinitionManager) ContainerManager.getComponent("variableDefinitionManager");
@@ -456,7 +458,7 @@ public class ServerNotificationTransport implements NotificationTransport
      *
      * @param taskResults Collection of all defined tasks with details
      * @return JSONArray containing the name and state
-     * @throws JSONException
+     * @throws JSONException if JSONObject can't be created
      */
     private JSONArray createTasksJSONArray(Collection<TaskResult> taskResults) throws JSONException {
         logToBuildLog("Creating tasks JSON array");

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -311,8 +311,8 @@ public class ServerNotificationTransport implements NotificationTransport
                                 logErrorToBuildLog("Could not load cached test results!");
                             }
                             logToBuildLog("Loading artifacts for job " + buildResultsSummary.getId());
-                            JSONArray staticAssessmentReports = createStaticAssessmentReportArray(buildResultsSummary.getProducedArtifactLinks(), buildResultsSummary.getId());
-                            jobDetails.put("staticAssessmentReports", staticAssessmentReports);
+                            JSONArray staticAssessmentReports = createStaticCodeAnalysisReportArray(buildResultsSummary.getProducedArtifactLinks(), buildResultsSummary.getId());
+                            jobDetails.put("staticCodeAnalysisReports", staticAssessmentReports);
 
 
                             List<LogEntry> logEntries = Collections.emptyList();
@@ -356,7 +356,7 @@ public class ServerNotificationTransport implements NotificationTransport
         return jsonObject;
     }
 
-    private Optional<JSONObject> createStaticAssessmentJSONObject(File rootFile, String label) {
+    private Optional<JSONObject> createStaticCodeAnalysisReportJSONObject(File rootFile, String label) {
         /*
          * The rootFile is a directory if the copy pattern matches multiple files, otherwise it is a regular file.
          * Ignore artifact definitions matching multiple files.
@@ -380,7 +380,7 @@ public class ServerNotificationTransport implements NotificationTransport
         return Optional.empty();
     }
 
-    private JSONArray createStaticAssessmentReportArray(Collection<ArtifactLink> artifactLinks, long jobId) {
+    private JSONArray createStaticCodeAnalysisReportArray(Collection<ArtifactLink> artifactLinks, long jobId) {
         JSONArray artifactsArray = new JSONArray();
         Collection<JSONObject> artifactJSONObjects = new ArrayList<>();
         // ArtifactLink refers to a single artifact definition configured on job level
@@ -407,7 +407,7 @@ public class ServerNotificationTransport implements NotificationTransport
             if (dataProvider instanceof FileSystemArtifactLinkDataProvider) {
                 FileSystemArtifactLinkDataProvider fileDataProvider = (FileSystemArtifactLinkDataProvider) dataProvider;
                 // TODO: Identify report in a more generic way
-                Optional<JSONObject> optionalReport = createStaticAssessmentJSONObject(fileDataProvider.getFile(), artifact.getLabel());
+                Optional<JSONObject> optionalReport = createStaticCodeAnalysisReportJSONObject(fileDataProvider.getFile(), artifact.getLabel());
                 optionalReport.ifPresent(artifactJSONObjects::add);
             } else {
                 log.debug("Unsupported ArtifactLinkDataProvider " + dataProvider.getClass().getSimpleName()

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/ReportParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/ReportParser.java
@@ -6,12 +6,10 @@ import de.tum.in.www1.bamboo.server.parser.exception.ParserException;
 import de.tum.in.www1.bamboo.server.parser.exception.UnsupportedToolException;
 import de.tum.in.www1.bamboo.server.parser.strategy.ParserPolicy;
 import de.tum.in.www1.bamboo.server.parser.strategy.ParserStrategy;
-import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
+import nu.xom.Builder;
+import nu.xom.Document;
+import nu.xom.ParsingException;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
 
@@ -45,15 +43,13 @@ public class ReportParser {
         }
     }
 
-    private Report getReport(File file, String tool) throws UnsupportedToolException, ParserConfigurationException, SAXException, IOException {
+    private Report getReport(File file, String tool) throws UnsupportedToolException, ParsingException, IOException {
         // Configure the strategy given the name of the tool
         parserPolicy.configure(tool);
 
-        // TODO: Use XOM, JDOM, DOM4J instead of DOM (for Collection support)
         // Build the DOM and parse the document using the configured strategy
-        DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
-        DocumentBuilder db = builderFactory.newDocumentBuilder();
-        Document doc = db.parse(file);
+        Builder parser = new Builder();
+        Document doc = parser.build(file);
         return parserStrategy.parse(doc);
     }
 }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public class Issue {
 
     // Path to the source file with unix file separators
-    private String file;
+    private String filePath;
 
     /**
      * Usage of line and column attributes by tools:
@@ -35,16 +35,16 @@ public class Issue {
     public Issue() {
     }
 
-    public Issue(String file) {
-        this.file = file;
+    public Issue(String filePath) {
+        this.filePath = filePath;
     }
 
-    public String getFile() {
-        return file;
+    public String getFilePath() {
+        return filePath;
     }
 
-    public void setFile(String file) {
-        this.file = file;
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
     }
 
     public Integer getStartLine() {

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
@@ -22,6 +22,9 @@ public class Issue {
 
     private Integer endColumn;
 
+    public Issue() {
+    }
+
     public Issue(String classname) {
         this.classname = classname;
     }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
@@ -5,9 +5,15 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Issue {
 
-    // Path of to the source file using unix file separators
+    // Path to the source file with unix file separators
     private String file;
 
+    /**
+     * Usage of line and column attributes by tools:
+     * Spotbugs -> startLine
+     * Checkstyle -> startLine, startColumn
+     * PMD -> startLine, endLine, startColumn, endColumn
+     */
     private Integer startLine;
 
     private Integer endLine;

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
@@ -14,13 +14,16 @@ public class Issue {
 
     private Integer line;
 
-    public Issue(String classname, String type, String priority, String category, String message, Integer line) {
+    private Integer column;
+
+    public Issue(String classname, String type, String priority, String category, String message, Integer line, Integer column) {
         this.classname = classname;
         this.type = type;
         this.priority = priority;
         this.category = category;
         this.message = message;
         this.line = line;
+        this.column = column;
     }
 
     public String getClassname() {
@@ -69,5 +72,13 @@ public class Issue {
 
     public void setLine(Integer line) {
         this.line = line;
+    }
+
+    public Integer getColumn() {
+        return column;
+    }
+
+    public void setColumn(Integer column) {
+        this.column = column;
     }
 }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
@@ -1,5 +1,8 @@
 package de.tum.in.www1.bamboo.server.parser.domain;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Issue {
 
     // Path of to the source file using unix file separators

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
@@ -10,8 +10,8 @@ public class Issue {
 
     /**
      * Usage of line and column attributes by tools:
-     * Spotbugs -> startLine
-     * Checkstyle -> startLine, startColumn
+     * Spotbugs -> startLine, endLine (duplicated startLine)
+     * Checkstyle -> startLine, endLine (duplicated startLine), startColumn, endColumn (duplicated startColumn)
      * PMD -> startLine, endLine, startColumn, endColumn
      */
     private Integer startLine;

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
@@ -2,9 +2,10 @@ package de.tum.in.www1.bamboo.server.parser.domain;
 
 public class Issue {
 
-    private String classname;
+    // Path of to the source file using unix file separators
+    private String file;
 
-    private String type;
+    private String rule;
 
     // TODO: This is currently not used in Artemis but could be useful for further filtering.
     // Map tool specific codes to a common format
@@ -25,24 +26,24 @@ public class Issue {
     public Issue() {
     }
 
-    public Issue(String classname) {
-        this.classname = classname;
+    public Issue(String file) {
+        this.file = file;
     }
 
-    public String getClassname() {
-        return classname;
+    public String getFile() {
+        return this.file;
     }
 
-    public void setClassname(String classname) {
-        this.classname = classname;
+    public void setFile(String file) {
+        this.file = file;
     }
 
-    public String getType() {
-        return type;
+    public String getRule() {
+        return rule;
     }
 
-    public void setType(String type) {
-        this.type = type;
+    public void setRule(String rule) {
+        this.rule = rule;
     }
 
     public String getPriority() {

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
@@ -6,24 +6,24 @@ public class Issue {
 
     private String type;
 
+    // TODO: This is currently not used in Artemis but could be useful for further filtering.
+    // Map tool specific codes to a common format
     private String priority;
 
     private String category;
 
     private String message;
 
-    private Integer line;
+    private Integer startLine;
 
-    private Integer column;
+    private Integer endLine;
 
-    public Issue(String classname, String type, String priority, String category, String message, Integer line, Integer column) {
+    private Integer startColumn;
+
+    private Integer endColumn;
+
+    public Issue(String classname) {
         this.classname = classname;
-        this.type = type;
-        this.priority = priority;
-        this.category = category;
-        this.message = message;
-        this.line = line;
-        this.column = column;
     }
 
     public String getClassname() {
@@ -66,19 +66,35 @@ public class Issue {
         this.message = message;
     }
 
-    public Integer getLine() {
-        return line;
+    public Integer getStartLine() {
+        return startLine;
     }
 
-    public void setLine(Integer line) {
-        this.line = line;
+    public void setStartLine(Integer startLine) {
+        this.startLine = startLine;
     }
 
-    public Integer getColumn() {
-        return column;
+    public Integer getEndLine() {
+        return endLine;
     }
 
-    public void setColumn(Integer column) {
-        this.column = column;
+    public void setEndLine(Integer endLine) {
+        this.endLine = endLine;
+    }
+
+    public Integer getStartColumn() {
+        return startColumn;
+    }
+
+    public void setStartColumn(Integer startColumn) {
+        this.startColumn = startColumn;
+    }
+
+    public Integer getEndColumn() {
+        return endColumn;
+    }
+
+    public void setEndColumn(Integer endColumn) {
+        this.endColumn = endColumn;
     }
 }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Issue.java
@@ -5,16 +5,6 @@ public class Issue {
     // Path of to the source file using unix file separators
     private String file;
 
-    private String rule;
-
-    // TODO: This is currently not used in Artemis but could be useful for further filtering.
-    // Map tool specific codes to a common format
-    private String priority;
-
-    private String category;
-
-    private String message;
-
     private Integer startLine;
 
     private Integer endLine;
@@ -22,6 +12,16 @@ public class Issue {
     private Integer startColumn;
 
     private Integer endColumn;
+
+    private String rule;
+
+    private String category;
+
+    private String message;
+
+    // TODO: This is currently not used in Artemis but could be useful for further filtering.
+    // Map tool specific codes to a common format
+    private String priority;
 
     public Issue() {
     }
@@ -31,43 +31,11 @@ public class Issue {
     }
 
     public String getFile() {
-        return this.file;
+        return file;
     }
 
     public void setFile(String file) {
         this.file = file;
-    }
-
-    public String getRule() {
-        return rule;
-    }
-
-    public void setRule(String rule) {
-        this.rule = rule;
-    }
-
-    public String getPriority() {
-        return priority;
-    }
-
-    public void setPriority(String priority) {
-        this.priority = priority;
-    }
-
-    public String getCategory() {
-        return category;
-    }
-
-    public void setCategory(String category) {
-        this.category = category;
-    }
-
-    public String getMessage() {
-        return message;
-    }
-
-    public void setMessage(String message) {
-        this.message = message;
     }
 
     public Integer getStartLine() {
@@ -100,5 +68,37 @@ public class Issue {
 
     public void setEndColumn(Integer endColumn) {
         this.endColumn = endColumn;
+    }
+
+    public String getRule() {
+        return rule;
+    }
+
+    public void setRule(String rule) {
+        this.rule = rule;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getPriority() {
+        return priority;
+    }
+
+    public void setPriority(String priority) {
+        this.priority = priority;
     }
 }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Report.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/Report.java
@@ -4,19 +4,19 @@ import java.util.List;
 
 public class Report {
 
-    private StaticAssessmentTool tool;
+    private StaticCodeAnalysisTool tool;
 
     private List<Issue> issues;
 
-    public Report(StaticAssessmentTool tool) {
+    public Report(StaticCodeAnalysisTool tool) {
         this.tool = tool;;
     }
 
-    public StaticAssessmentTool getTool() {
+    public StaticCodeAnalysisTool getTool() {
         return tool;
     }
 
-    public void setTool(StaticAssessmentTool tool) {
+    public void setTool(StaticCodeAnalysisTool tool) {
         this.tool = tool;
     }
 

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/StaticAssessmentTool.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/StaticAssessmentTool.java
@@ -1,5 +1,5 @@
 package de.tum.in.www1.bamboo.server.parser.domain;
 
 public enum StaticAssessmentTool {
-    SPOTBUGS, CHECKSYTLE, PMD
+    SPOTBUGS, CHECKSTYLE, PMD
 }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/StaticAssessmentTool.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/StaticAssessmentTool.java
@@ -1,5 +1,5 @@
 package de.tum.in.www1.bamboo.server.parser.domain;
 
 public enum StaticAssessmentTool {
-    SPOTBUGS
+    SPOTBUGS, CHECKSYTLE, PMD
 }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/StaticCodeAnalysisTool.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/domain/StaticCodeAnalysisTool.java
@@ -1,5 +1,5 @@
 package de.tum.in.www1.bamboo.server.parser.domain;
 
-public enum StaticAssessmentTool {
+public enum StaticCodeAnalysisTool {
     SPOTBUGS, CHECKSTYLE, PMD
 }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/exception/UnsupportedToolException.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/exception/UnsupportedToolException.java
@@ -1,6 +1,6 @@
 package de.tum.in.www1.bamboo.server.parser.exception;
 
-public class UnsupportedToolException extends Exception {
+public class UnsupportedToolException extends RuntimeException {
 
     public UnsupportedToolException(String message) {
         super(message);

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/CheckstyleParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/CheckstyleParser.java
@@ -1,0 +1,70 @@
+package de.tum.in.www1.bamboo.server.parser.strategy;
+
+import de.tum.in.www1.bamboo.server.parser.domain.Issue;
+import de.tum.in.www1.bamboo.server.parser.domain.Report;
+import de.tum.in.www1.bamboo.server.parser.domain.StaticAssessmentTool;
+import nu.xom.Document;
+import nu.xom.Element;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CheckstyleParser implements ParserStrategy {
+
+    private static final String FILE_TAG = "file";
+    private static final String FILE_ATT_NAME = "name";
+    /**
+     * The source attribute of error elements looks like com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck
+     * where the first segment after 'checks' denotes the category and the segment after denotes rule. The are rules
+     * which do not belong to a category e.g. com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck. In this
+     * case we will use the rule name as the category.
+     */
+    private static final String ERROR_ATT_SOURCE = "source";
+    private static final String ERROR_ATT_SEVERITY = "severity";
+    private static final String ERROR_ATT_MESSAGE = "message";
+    private static final String ERROR_ATT_LINENUMBER = "line";
+    private static final String ERROR_ATT_COLUMN = "column";
+    private static final String CATEGORY_DELIMITER = "checks";
+
+    @Override
+    public Report parse(Document doc) {
+        Report report = new Report(StaticAssessmentTool.CHECKSYTLE);
+        List<Issue> issues = new ArrayList<>();
+        Element root = doc.getRootElement();
+
+        // Iterate over all <file> elements
+        for (Element fileElement : root.getChildElements(FILE_TAG)) {
+            String classname = fileElement.getAttributeValue(FILE_ATT_NAME);
+
+            // Iterate over all <error> elements
+            for (Element errorElement : fileElement.getChildElements()) {
+                String errorSource = errorElement.getAttributeValue(ERROR_ATT_SOURCE);
+                String[] errorSegments = errorSource.split("\\.");
+                String type = errorSegments[errorSegments.length - 1];
+                String category = errorSegments[errorSegments.length - 2];
+                if (category.equals(CATEGORY_DELIMITER)) {
+                    category = type;
+                }
+                String priority = errorElement.getAttributeValue(ERROR_ATT_SEVERITY);
+                String message = errorElement.getAttributeValue(ERROR_ATT_MESSAGE);
+                Integer line;
+                try {
+                    line = Integer.parseInt(errorElement.getAttributeValue(ERROR_ATT_LINENUMBER));
+                } catch (NumberFormatException e) {
+                    // If for some reason the line number can't be parsed, we default to line 0
+                    line = 0;
+                }
+                Integer column;
+                try {
+                    column = Integer.parseInt(errorElement.getAttributeValue(ERROR_ATT_COLUMN));
+                } catch (NumberFormatException e) {
+                    // If for some reason the column number can't be parsed, we default to column 0
+                    column = 0;
+                }
+                issues.add(new Issue(classname, type, priority, category, message, line, column));
+            }
+        }
+        report.setIssues(issues);
+        return report;
+    }
+}

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/CheckstyleParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/CheckstyleParser.java
@@ -32,11 +32,11 @@ public class CheckstyleParser implements ParserStrategy {
 
         // Iterate over all <file> elements
         for (Element fileElement : root.getChildElements(FILE_TAG)) {
-            String file = ParserUtils.shortenAndTransformToUnixPath(fileElement.getAttributeValue(FILE_ATT_NAME));
+            String unixPath = ParserUtils.transformToUnixPath(fileElement.getAttributeValue(FILE_ATT_NAME));
 
             // Iterate over all <error> elements
             for (Element errorElement : fileElement.getChildElements()) {
-                Issue issue = new Issue(file);
+                Issue issue = new Issue(unixPath);
 
                 String errorSource = errorElement.getAttributeValue(ERROR_ATT_SOURCE);
                 extractRuleAndCategory(issue, errorSource);

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/CheckstyleParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/CheckstyleParser.java
@@ -30,11 +30,12 @@ public class CheckstyleParser implements ParserStrategy {
 
         // Iterate over all <file> elements
         for (Element fileElement : root.getChildElements(FILE_TAG)) {
-            String classPath = transformToFullyQualifiedClassName(fileElement.getAttributeValue(FILE_ATT_NAME));
+            String filePath = fileElement.getAttributeValue(FILE_ATT_NAME);
+            String className = ParserUtils.transformPathToFullyQualifiedClassName(filePath);
 
             // Iterate over all <error> elements
             for (Element errorElement : fileElement.getChildElements()) {
-                Issue issue = new Issue(classPath);
+                Issue issue = new Issue(className);
 
                 String errorSource = errorElement.getAttributeValue(ERROR_ATT_SOURCE);
                 extractRuleAndCategory(issue, errorSource);
@@ -49,27 +50,6 @@ public class CheckstyleParser implements ParserStrategy {
         }
         report.setIssues(issues);
         return report;
-    }
-
-    /**
-     * Transform the path to a fully qualified class name starting at the src directory.
-     * If src directory is not part of the path, the whole path will be transformed to a dotted notation and returned.
-     *
-     * @param path absolute path like C:/BambooTest/src/com/abc/staticCodeAnalysis/App.java
-     * @return the package name like com.abc.staticCodeAnalysis.App
-     */
-    private String transformToFullyQualifiedClassName(String path) {
-        if (path == null || path.isEmpty()) {
-            return path;
-        }
-        String packageDelimiter = File.separator + "src" + File.separator;
-        int indexOfSrc = path.indexOf(packageDelimiter);
-        // Fallback: Return the whole path if no src folder exists
-        if (indexOfSrc == -1) {
-            return path.replace(File.separator, ".");
-        }
-        int javaExtensionIndex = path.endsWith(".java") ? path.length() - 5 : path.length();
-        return path.substring(indexOfSrc + packageDelimiter.length(), javaExtensionIndex).replace(File.separator, ".");
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/CheckstyleParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/CheckstyleParser.java
@@ -45,7 +45,7 @@ public class CheckstyleParser implements ParserStrategy {
                 issue.setPriority(errorElement.getAttributeValue(ERROR_ATT_SEVERITY));
                 issue.setMessage(errorElement.getAttributeValue(ERROR_ATT_MESSAGE));
                 issue.setStartLine(ParserUtils.extractInt(errorElement, ERROR_ATT_LINENUMBER));
-                issue.setEndColumn(ParserUtils.extractInt(errorElement, ERROR_ATT_COLUMN));
+                issue.setStartColumn(ParserUtils.extractInt(errorElement, ERROR_ATT_COLUMN));
 
                 issues.add(issue);
             }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/CheckstyleParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/CheckstyleParser.java
@@ -43,8 +43,16 @@ public class CheckstyleParser implements ParserStrategy {
 
                 issue.setPriority(errorElement.getAttributeValue(ERROR_ATT_SEVERITY));
                 issue.setMessage(errorElement.getAttributeValue(ERROR_ATT_MESSAGE));
-                issue.setStartLine(ParserUtils.extractInt(errorElement, ERROR_ATT_LINENUMBER));
-                issue.setStartColumn(ParserUtils.extractInt(errorElement, ERROR_ATT_COLUMN));
+
+                // Set startLine as endLine as Checkstyle does not support an end line
+                int startLine = ParserUtils.extractInt(errorElement, ERROR_ATT_LINENUMBER);
+                issue.setStartLine(startLine);
+                issue.setEndLine(startLine);
+
+                // Set startColumn as endColumn as Checkstyle does not support an end column
+                int startColumn = ParserUtils.extractInt(errorElement, ERROR_ATT_COLUMN);
+                issue.setStartColumn(startColumn);
+                issue.setEndColumn(startColumn);
 
                 issues.add(issue);
             }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/CheckstyleParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/CheckstyleParser.java
@@ -19,7 +19,10 @@ public class CheckstyleParser implements ParserStrategy {
     private static final String ERROR_ATT_MESSAGE = "message";
     private static final String ERROR_ATT_LINENUMBER = "line";
     private static final String ERROR_ATT_COLUMN = "column";
+
+    // The packages rooted at checks denote the category and rule
     private static final String CATEGORY_DELIMITER = "checks";
+    // Some rules don't belong to a category. We group them under this identifier.
     private static final String CATEGORY_MISCELLANEOUS = "miscellaneous";
 
     @Override
@@ -30,12 +33,11 @@ public class CheckstyleParser implements ParserStrategy {
 
         // Iterate over all <file> elements
         for (Element fileElement : root.getChildElements(FILE_TAG)) {
-            String filePath = fileElement.getAttributeValue(FILE_ATT_NAME);
-            String className = ParserUtils.transformPathToFullyQualifiedClassName(filePath);
+            String file = ParserUtils.shortenAndTransformToUnixPath(fileElement.getAttributeValue(FILE_ATT_NAME));
 
             // Iterate over all <error> elements
             for (Element errorElement : fileElement.getChildElements()) {
-                Issue issue = new Issue(className);
+                Issue issue = new Issue(file);
 
                 String errorSource = errorElement.getAttributeValue(ERROR_ATT_SOURCE);
                 extractRuleAndCategory(issue, errorSource);
@@ -70,14 +72,14 @@ public class CheckstyleParser implements ParserStrategy {
             issue.setCategory(errorSource);
             return;
         }
-        String type = errorSourceSegments[noOfSegments - 1];
+        String rule = errorSourceSegments[noOfSegments - 1];
         String category = errorSourceSegments[noOfSegments - 2];
 
         // Check if the rule has a category
         if (category.equals(CATEGORY_DELIMITER)) {
             category = CATEGORY_MISCELLANEOUS;
         }
-        issue.setType(type);
+        issue.setRule(rule);
         issue.setCategory(category);
     }
 }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/CheckstyleParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/CheckstyleParser.java
@@ -24,7 +24,7 @@ public class CheckstyleParser implements ParserStrategy {
 
     @Override
     public Report parse(Document doc) {
-        Report report = new Report(StaticAssessmentTool.CHECKSYTLE);
+        Report report = new Report(StaticAssessmentTool.CHECKSTYLE);
         List<Issue> issues = new ArrayList<>();
         Element root = doc.getRootElement();
 

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/CheckstyleParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/CheckstyleParser.java
@@ -2,11 +2,10 @@ package de.tum.in.www1.bamboo.server.parser.strategy;
 
 import de.tum.in.www1.bamboo.server.parser.domain.Issue;
 import de.tum.in.www1.bamboo.server.parser.domain.Report;
-import de.tum.in.www1.bamboo.server.parser.domain.StaticAssessmentTool;
+import de.tum.in.www1.bamboo.server.parser.domain.StaticCodeAnalysisTool;
 import nu.xom.Document;
 import nu.xom.Element;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,7 +26,7 @@ public class CheckstyleParser implements ParserStrategy {
 
     @Override
     public Report parse(Document doc) {
-        Report report = new Report(StaticAssessmentTool.CHECKSTYLE);
+        Report report = new Report(StaticCodeAnalysisTool.CHECKSTYLE);
         List<Issue> issues = new ArrayList<>();
         Element root = doc.getRootElement();
 

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/PMDParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/PMDParser.java
@@ -33,12 +33,11 @@ public class PMDParser implements ParserStrategy {
         // Iterate over all <file> elements
         for (Element fileElement : root.getChildElements(FILE_TAG, root.getNamespaceURI())) {
             // Extract the file path
-            String filePath = fileElement.getAttributeValue(FILE_ATT_NAME);
-            String shortenedPath = ParserUtils.shortenAndTransformToUnixPath(filePath);
+            String unixPath = ParserUtils.transformToUnixPath(fileElement.getAttributeValue(FILE_ATT_NAME));
 
             // Iterate over all <violation> elements
             for (Element violationElement : fileElement.getChildElements()) {
-                Issue issue = new Issue(shortenedPath);
+                Issue issue = new Issue(unixPath);
 
                 issue.setRule(violationElement.getAttributeValue(VIOLATION_ATT_RULE));
                 issue.setCategory(violationElement.getAttributeValue(VIOLATION_ATT_RULESET));

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/PMDParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/PMDParser.java
@@ -32,7 +32,7 @@ public class PMDParser implements ParserStrategy {
         Element root = doc.getRootElement();
 
         // Iterate over all <file> elements
-        for (Element fileElement : root.getChildElements(FILE_TAG)) {
+        for (Element fileElement : root.getChildElements(FILE_TAG, root.getNamespaceURI())) {
             // Extract the file path but use this only as a fallback more specific information is available
             String fileName = fileElement.getAttributeValue(FILE_ATT_NAME);
             String packageFromFileName = ParserUtils.transformPathToFullyQualifiedClassName(fileName);
@@ -49,6 +49,7 @@ public class PMDParser implements ParserStrategy {
                 issue.setEndLine(ParserUtils.extractInt(violationElement, VIOLATION_ATT_ENDLINE));
                 issue.setStartColumn(ParserUtils.extractInt(violationElement, VIOLATION_ATT_BEGINCOLUMN));
                 issue.setEndColumn(ParserUtils.extractInt(violationElement, VIOLATION_ATT_ENDCOLUMN));
+                issue.setMessage(violationElement.getValue());
 
                 issues.add(issue);
             }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/PMDParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/PMDParser.java
@@ -1,0 +1,76 @@
+package de.tum.in.www1.bamboo.server.parser.strategy;
+
+import de.tum.in.www1.bamboo.server.parser.domain.Issue;
+import de.tum.in.www1.bamboo.server.parser.domain.Report;
+import de.tum.in.www1.bamboo.server.parser.domain.StaticAssessmentTool;
+import nu.xom.Document;
+import nu.xom.Element;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class PMDParser implements ParserStrategy {
+
+    // XSD for PMD XML reports: https://github.com/pmd/pmd/blob/master/pmd-core/src/main/resources/report_2_0_0.xsd
+    private static final String FILE_TAG = "file";
+    private static final String FILE_ATT_NAME = "name";
+    private static final String VIOLATION_ATT_CLASS = "class";
+    private static final String VIOLATION_ATT_PACKAGE = "package";
+    private static final String VIOLATION_ATT_RULE = "rule";
+    private static final String VIOLATION_ATT_RULESET = "ruleset";
+    private static final String VIOLATION_ATT_PRIORITY = "priority";
+    private static final String VIOLATION_ATT_BEGINLINE = "beginline";
+    private static final String VIOLATION_ATT_ENDLINE = "endline";
+    private static final String VIOLATION_ATT_BEGINCOLUMN = "begincolumn";
+    private static final String VIOLATION_ATT_ENDCOLUMN = "endcolumn";
+
+    @Override
+    public Report parse(Document doc) {
+        Report report = new Report(StaticAssessmentTool.PMD);
+        List<Issue> issues = new ArrayList<>();
+        Element root = doc.getRootElement();
+
+        // Iterate over all <file> elements
+        for (Element fileElement : root.getChildElements(FILE_TAG)) {
+            // Extract the file path but use this only as a fallback more specific information is available
+            String fileName = fileElement.getAttributeValue(FILE_ATT_NAME);
+            String packageFromFileName = ParserUtils.transformPathToFullyQualifiedClassName(fileName);
+
+            // Iterate over all <violation> elements
+            for (Element violationElement : fileElement.getChildElements()) {
+                Issue issue = new Issue();
+
+                issue.setClassname(buildFullyQualifiedClassName(violationElement).orElse(packageFromFileName));
+                issue.setType(violationElement.getAttributeValue(VIOLATION_ATT_RULE));
+                issue.setCategory(violationElement.getAttributeValue(VIOLATION_ATT_RULESET));
+                issue.setPriority(violationElement.getAttributeValue(VIOLATION_ATT_PRIORITY));
+                issue.setStartLine(ParserUtils.extractInt(violationElement, VIOLATION_ATT_BEGINLINE));
+                issue.setEndLine(ParserUtils.extractInt(violationElement, VIOLATION_ATT_ENDLINE));
+                issue.setStartColumn(ParserUtils.extractInt(violationElement, VIOLATION_ATT_BEGINCOLUMN));
+                issue.setEndColumn(ParserUtils.extractInt(violationElement, VIOLATION_ATT_ENDCOLUMN));
+
+                issues.add(issue);
+            }
+        }
+        report.setIssues(issues);
+        return report;
+    }
+
+    /**
+     * Build the fully qualified class name using the package and class attribute values.
+     * As the XSD defines those attributes as optional, an empty optional is returned if one attribute does not exist.
+     *
+     * @param violationElement Violation element of the PMD report
+     * @return Optional containing the fully qualified class name. Empty if package or class attribute doesn't exist
+     */
+    private Optional<String> buildFullyQualifiedClassName(Element violationElement) {
+        String className = violationElement.getAttributeValue(VIOLATION_ATT_CLASS);
+        String packageName = violationElement.getAttributeValue(VIOLATION_ATT_PACKAGE);
+        if (className == null || packageName == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(packageName + "." + className);
+        }
+    }
+}

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/PMDParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/PMDParser.java
@@ -49,7 +49,8 @@ public class PMDParser implements ParserStrategy {
                 issue.setEndLine(ParserUtils.extractInt(violationElement, VIOLATION_ATT_ENDLINE));
                 issue.setStartColumn(ParserUtils.extractInt(violationElement, VIOLATION_ATT_BEGINCOLUMN));
                 issue.setEndColumn(ParserUtils.extractInt(violationElement, VIOLATION_ATT_ENDCOLUMN));
-                issue.setMessage(violationElement.getValue());
+                // Strip new lines and whitespace from the text element
+                issue.setMessage(violationElement.getValue().replaceAll("(\\r|\\n)", "").trim());
 
                 issues.add(issue);
             }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/PMDParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/PMDParser.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.bamboo.server.parser.strategy;
 
 import de.tum.in.www1.bamboo.server.parser.domain.Issue;
 import de.tum.in.www1.bamboo.server.parser.domain.Report;
-import de.tum.in.www1.bamboo.server.parser.domain.StaticAssessmentTool;
+import de.tum.in.www1.bamboo.server.parser.domain.StaticCodeAnalysisTool;
 import nu.xom.Document;
 import nu.xom.Element;
 
@@ -26,7 +26,7 @@ public class PMDParser implements ParserStrategy {
 
     @Override
     public Report parse(Document doc) {
-        Report report = new Report(StaticAssessmentTool.PMD);
+        Report report = new Report(StaticCodeAnalysisTool.PMD);
         List<Issue> issues = new ArrayList<>();
         Element root = doc.getRootElement();
 

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserPolicy.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserPolicy.java
@@ -16,13 +16,21 @@ public class ParserPolicy {
      * Selects the appropriate parsing strategy.
      *
      * @param tool String identifying the static code analysis tool
-     * @throws UnsupportedToolException - If specified Tool is not supported
+     * @throws UnsupportedToolException - If the specified tool is not supported
      */
-    public void configure(String tool) throws UnsupportedToolException {
+    public void configure(String tool) {
         // TODO: Inspect the document (identifying unique nodes) to select the appropriate strategy
         if (StaticAssessmentTool.SPOTBUGS.name().equalsIgnoreCase(tool)) {
             parser.setParserStrategy(new SpotbugsParser());
-        } else {
+        }
+        else if (StaticAssessmentTool.CHECKSYTLE.name().equalsIgnoreCase(tool)) {
+            parser.setParserStrategy(new CheckstyleParser());
+        }
+         /**
+        else if (StaticAssessmentTool.PMD.name().equalsIgnoreCase(tool)) {
+            parser.setParserStrategy(new PMDParser());
+         **/
+        else {
             throw new UnsupportedToolException("Report parsing for tool" + tool + "is not supported");
         }
     }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserPolicy.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserPolicy.java
@@ -26,10 +26,9 @@ public class ParserPolicy {
         else if (StaticAssessmentTool.CHECKSYTLE.name().equalsIgnoreCase(tool)) {
             parser.setParserStrategy(new CheckstyleParser());
         }
-         /**
         else if (StaticAssessmentTool.PMD.name().equalsIgnoreCase(tool)) {
             parser.setParserStrategy(new PMDParser());
-         **/
+        }
         else {
             throw new UnsupportedToolException("Report parsing for tool" + tool + "is not supported");
         }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserPolicy.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserPolicy.java
@@ -1,7 +1,7 @@
 package de.tum.in.www1.bamboo.server.parser.strategy;
 
 import de.tum.in.www1.bamboo.server.parser.ReportParser;
-import de.tum.in.www1.bamboo.server.parser.domain.StaticAssessmentTool;
+import de.tum.in.www1.bamboo.server.parser.domain.StaticCodeAnalysisTool;
 import de.tum.in.www1.bamboo.server.parser.exception.UnsupportedToolException;
 
 public class ParserPolicy {
@@ -20,13 +20,13 @@ public class ParserPolicy {
      */
     public void configure(String tool) {
         // TODO: Inspect the document (identifying unique nodes) to select the appropriate strategy
-        if (StaticAssessmentTool.SPOTBUGS.name().equalsIgnoreCase(tool)) {
+        if (StaticCodeAnalysisTool.SPOTBUGS.name().equalsIgnoreCase(tool)) {
             parser.setParserStrategy(new SpotbugsParser());
         }
-        else if (StaticAssessmentTool.CHECKSTYLE.name().equalsIgnoreCase(tool)) {
+        else if (StaticCodeAnalysisTool.CHECKSTYLE.name().equalsIgnoreCase(tool)) {
             parser.setParserStrategy(new CheckstyleParser());
         }
-        else if (StaticAssessmentTool.PMD.name().equalsIgnoreCase(tool)) {
+        else if (StaticCodeAnalysisTool.PMD.name().equalsIgnoreCase(tool)) {
             parser.setParserStrategy(new PMDParser());
         }
         else {

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserPolicy.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserPolicy.java
@@ -23,14 +23,14 @@ public class ParserPolicy {
         if (StaticAssessmentTool.SPOTBUGS.name().equalsIgnoreCase(tool)) {
             parser.setParserStrategy(new SpotbugsParser());
         }
-        else if (StaticAssessmentTool.CHECKSYTLE.name().equalsIgnoreCase(tool)) {
+        else if (StaticAssessmentTool.CHECKSTYLE.name().equalsIgnoreCase(tool)) {
             parser.setParserStrategy(new CheckstyleParser());
         }
         else if (StaticAssessmentTool.PMD.name().equalsIgnoreCase(tool)) {
             parser.setParserStrategy(new PMDParser());
         }
         else {
-            throw new UnsupportedToolException("Report parsing for tool" + tool + "is not supported");
+            throw new UnsupportedToolException("Report parsing for tool " + tool + " is not supported");
         }
     }
 }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserStrategy.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserStrategy.java
@@ -1,7 +1,7 @@
 package de.tum.in.www1.bamboo.server.parser.strategy;
 
 import de.tum.in.www1.bamboo.server.parser.domain.Report;
-import org.w3c.dom.Document;
+import nu.xom.Document;
 
 
 public interface ParserStrategy {
@@ -9,7 +9,7 @@ public interface ParserStrategy {
     /**
      * Parse a static code analysis report into a common Java representation.
      *
-     * @param doc W3C DOM Document
+     * @param doc XOM DOM Document
      * @return Report object containing the parsed report information
      */
     Report parse(Document doc);

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserStrategy.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserStrategy.java
@@ -13,5 +13,4 @@ public interface ParserStrategy {
      * @return Report object containing the parsed report information
      */
     Report parse(Document doc);
-
 }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserUtils.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserUtils.java
@@ -3,6 +3,7 @@ package de.tum.in.www1.bamboo.server.parser.strategy;
 import nu.xom.Element;
 
 import java.io.File;
+import java.util.regex.Pattern;
 
 /**
  * Utility class providing shared functionality for report parsing
@@ -25,23 +26,33 @@ public class ParserUtils {
     }
 
     /**
-     * Transform the path to a fully qualified class name starting at the src directory.
-     * If src directory is not part of the path, the whole path will be transformed to a dotted notation and returned.
+     * Shorten the path to start after the source directory, which is assumed to be '/assignment/src/'.
+     * Returns the path using unix file separators.
+     * If '/assignment/src/' is not found, the whole path will be returned.
      *
-     * @param path Absolute path like C:/BambooTest/src/com/abc/staticCodeAnalysis/App.java
-     * @return Package name like com.abc.staticCodeAnalysis.App
+     * @param path Absolute path like C:\BambooTest\assignment\src\com\abc\staticCodeAnalysis\App.java
+     * @return path like com/abc/staticCodeAnalysis/App.java]
      */
-    public static String transformPathToFullyQualifiedClassName(String path) {
+    public static String shortenAndTransformToUnixPath(String path) {
         if (path == null || path.isEmpty()) {
             return path;
         }
-        String packageDelimiter = File.separator + "src" + File.separator;
+        String packageDelimiter = File.separator + "assignment" + File.separator + "src" + File.separator;
         int indexOfSrc = path.indexOf(packageDelimiter);
-        // Fallback: Return the whole path if no src folder exists
+
+        // Fallback: Return the whole path if no assignment/src segment exists
         if (indexOfSrc == -1) {
-            return path.replace(File.separator, ".");
+            return transformToUnixPath(path);
         }
-        int javaExtensionIndex = path.endsWith(".java") ? path.length() - 5 : path.length();
-        return path.substring(indexOfSrc + packageDelimiter.length(), javaExtensionIndex).replace(File.separator, ".");
+        return transformToUnixPath(path.substring(indexOfSrc + packageDelimiter.length()));
+    }
+
+    public static String transformToUnixPath(String path) {
+        String fileDelimiterRegex = Pattern.quote(File.separator);
+        return path.replace(File.separator, "/");
+    }
+
+    public static String stripNewLinesAndWhitespace(String text) {
+        return text.replaceAll("(\\r|\\n)", "").trim();
     }
 }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserUtils.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserUtils.java
@@ -26,33 +26,28 @@ public class ParserUtils {
     }
 
     /**
-     * Shorten the path to start after the source directory, which is assumed to be '/assignment/src/'.
-     * Returns the path using unix file separators.
-     * If '/assignment/src/' is not found, the whole path will be returned.
+     * Transforms operating system dependent file separators in a path to unix file separators
      *
-     * @param path Absolute path like C:\BambooTest\assignment\src\com\abc\staticCodeAnalysis\App.java
-     * @return path like com/abc/staticCodeAnalysis/App.java]
+     * @param path String representation of a path to be transformed
+     * @return path with unix file separators
      */
-    public static String shortenAndTransformToUnixPath(String path) {
+    public static String transformToUnixPath(String path) {
         if (path == null || path.isEmpty()) {
             return path;
         }
-        String packageDelimiter = File.separator + "assignment" + File.separator + "src" + File.separator;
-        int indexOfSrc = path.indexOf(packageDelimiter);
-
-        // Fallback: Return the whole path if no assignment/src segment exists
-        if (indexOfSrc == -1) {
-            return transformToUnixPath(path);
-        }
-        return transformToUnixPath(path.substring(indexOfSrc + packageDelimiter.length()));
-    }
-
-    public static String transformToUnixPath(String path) {
-        String fileDelimiterRegex = Pattern.quote(File.separator);
         return path.replace(File.separator, "/");
     }
 
+    /**
+     * Strips new lines and trailing or leading whitespaces in a String
+     *
+     * @param text to strip
+     * @return striped text
+     */
     public static String stripNewLinesAndWhitespace(String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
         return text.replaceAll("(\\r|\\n)", "").trim();
     }
 }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserUtils.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserUtils.java
@@ -1,0 +1,25 @@
+package de.tum.in.www1.bamboo.server.parser.strategy;
+
+import nu.xom.Element;
+
+/**
+ * Utility class providing shared functionality for report parsing
+ */
+public class ParserUtils {
+
+    /**
+     * Extracts and parses an attribute to an int. Defaults to 0 if parsing fails
+     *
+     * @param element Element with attributes
+     * @param attribute Attribute  to extract
+     * @return extracted number
+     */
+    public static int extractInt(Element element, String attribute) {
+        try {
+            return Integer.parseInt(element.getAttributeValue(attribute));
+        } catch (NumberFormatException e) {
+            // If for some reason the line number can't be parsed, we default to line 0
+            return 0;
+        }
+    }
+}

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserUtils.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/ParserUtils.java
@@ -2,13 +2,15 @@ package de.tum.in.www1.bamboo.server.parser.strategy;
 
 import nu.xom.Element;
 
+import java.io.File;
+
 /**
  * Utility class providing shared functionality for report parsing
  */
 public class ParserUtils {
 
     /**
-     * Extracts and parses an attribute to an int. Defaults to 0 if parsing fails
+     * Extracts and parses an attribute to an int. Defaults to 0 if parsing fails.
      *
      * @param element Element with attributes
      * @param attribute Attribute  to extract
@@ -18,8 +20,28 @@ public class ParserUtils {
         try {
             return Integer.parseInt(element.getAttributeValue(attribute));
         } catch (NumberFormatException e) {
-            // If for some reason the line number can't be parsed, we default to line 0
             return 0;
         }
+    }
+
+    /**
+     * Transform the path to a fully qualified class name starting at the src directory.
+     * If src directory is not part of the path, the whole path will be transformed to a dotted notation and returned.
+     *
+     * @param path Absolute path like C:/BambooTest/src/com/abc/staticCodeAnalysis/App.java
+     * @return Package name like com.abc.staticCodeAnalysis.App
+     */
+    public static String transformPathToFullyQualifiedClassName(String path) {
+        if (path == null || path.isEmpty()) {
+            return path;
+        }
+        String packageDelimiter = File.separator + "src" + File.separator;
+        int indexOfSrc = path.indexOf(packageDelimiter);
+        // Fallback: Return the whole path if no src folder exists
+        if (indexOfSrc == -1) {
+            return path.replace(File.separator, ".");
+        }
+        int javaExtensionIndex = path.endsWith(".java") ? path.length() - 5 : path.length();
+        return path.substring(indexOfSrc + packageDelimiter.length(), javaExtensionIndex).replace(File.separator, ".");
     }
 }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/SpotbugsParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/SpotbugsParser.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.bamboo.server.parser.strategy;
 
 import de.tum.in.www1.bamboo.server.parser.domain.Issue;
 import de.tum.in.www1.bamboo.server.parser.domain.Report;
-import de.tum.in.www1.bamboo.server.parser.domain.StaticAssessmentTool;
+import de.tum.in.www1.bamboo.server.parser.domain.StaticCodeAnalysisTool;
 import nu.xom.Document;
 import nu.xom.Element;
 import nu.xom.Elements;
@@ -23,7 +23,7 @@ public class SpotbugsParser implements ParserStrategy {
 
     @Override
     public Report parse(Document doc) {
-        Report report = new Report(StaticAssessmentTool.SPOTBUGS);
+        Report report = new Report(StaticCodeAnalysisTool.SPOTBUGS);
         List<Issue> issues = new ArrayList<>();
         // Element BugCollection
         Element root = doc.getRootElement();

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/SpotbugsParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/SpotbugsParser.java
@@ -42,7 +42,7 @@ public class SpotbugsParser implements ParserStrategy {
             if (sourceLines.size() > 0) {
                 Element sourceLine = sourceLines.get(0);
                 // The sourcePath begins with the package name so we don't need to shorten it
-                issue.setFile(ParserUtils.transformToUnixPath(sourceLine.getAttributeValue(SOURCELINE_ATT_SOURCEPATH)));
+                issue.setFilePath(ParserUtils.transformToUnixPath(sourceLine.getAttributeValue(SOURCELINE_ATT_SOURCEPATH)));
                 // Set endLine by duplicating the startLine. Spotbugs does not support a endLine
                 int startLine = ParserUtils.extractInt(sourceLine, SOURCELINE_ATT_START);
                 issue.setStartLine(startLine);

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/SpotbugsParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/SpotbugsParser.java
@@ -42,7 +42,8 @@ public class SpotbugsParser implements ParserStrategy {
             if (sourceLines.size() > 0) {
                 Element sourceLine = sourceLines.get(0);
                 // The sourcePath begins with the package name so we don't need to shorten it
-                issue.setFilePath(ParserUtils.transformToUnixPath(sourceLine.getAttributeValue(SOURCELINE_ATT_SOURCEPATH)));
+                String unixPath = ParserUtils.transformToUnixPath(sourceLine.getAttributeValue(SOURCELINE_ATT_SOURCEPATH));
+                issue.setFilePath(unixPath);
                 // Set endLine by duplicating the startLine. Spotbugs does not support a endLine
                 int startLine = ParserUtils.extractInt(sourceLine, SOURCELINE_ATT_START);
                 issue.setStartLine(startLine);

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/SpotbugsParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/SpotbugsParser.java
@@ -43,7 +43,10 @@ public class SpotbugsParser implements ParserStrategy {
                 Element sourceLine = sourceLines.get(0);
                 // The sourcePath begins with the package name so we don't need to shorten it
                 issue.setFile(ParserUtils.transformToUnixPath(sourceLine.getAttributeValue(SOURCELINE_ATT_SOURCEPATH)));
-                issue.setStartLine(ParserUtils.extractInt(sourceLine, SOURCELINE_ATT_START));
+                // Set endLine by duplicating the startLine. Spotbugs does not support a endLine
+                int startLine = ParserUtils.extractInt(sourceLine, SOURCELINE_ATT_START);
+                issue.setStartLine(startLine);
+                issue.setEndLine(startLine);
             }
 
             // Extract message

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/SpotbugsParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/SpotbugsParser.java
@@ -37,6 +37,7 @@ public class SpotbugsParser implements ParserStrategy {
                 issue.setPriority(bugInstanceElement.getAttributeValue(BUGINSTANCE_ATT_PRIORITY));
                 issue.setCategory(bugInstanceElement.getAttributeValue(BUGINSTANCE_ATT_CATEGORY));
                 issue.setMessage(bugInstanceElement.getAttributeValue(BUGINSTANCE_ATT_MESSAGE));
+                issue.setStartLine(ParserUtils.extractInt(bugInstanceElement, BUGINSTANCE_ATT_LINENUMBER));
 
                 issues.add(issue);
             }

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/SpotbugsParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/SpotbugsParser.java
@@ -27,11 +27,11 @@ public class SpotbugsParser implements ParserStrategy {
 
         // Iterate over <file> elements
         for (Element fileElement : root.getChildElements(FILE_TAG)) {
-            String classpath = fileElement.getAttributeValue(FILE_ATT_CLASSNAME);
+            String className = fileElement.getAttributeValue(FILE_ATT_CLASSNAME);
 
             // Iterate over <bugInstance> elements
             for (Element bugInstanceElement : fileElement.getChildElements()) {
-                Issue issue = new Issue(classpath);
+                Issue issue = new Issue(className);
 
                 issue.setType(bugInstanceElement.getAttributeValue(BUGINSTANCE_ATT_TYPE));
                 issue.setPriority(bugInstanceElement.getAttributeValue(BUGINSTANCE_ATT_PRIORITY));

--- a/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/SpotbugsParser.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/parser/strategy/SpotbugsParser.java
@@ -25,22 +25,20 @@ public class SpotbugsParser implements ParserStrategy {
         List<Issue> issues = new ArrayList<>();
         Element root = doc.getRootElement();
 
+        // Iterate over <file> elements
         for (Element fileElement : root.getChildElements(FILE_TAG)) {
-            String classname = fileElement.getAttributeValue(FILE_ATT_CLASSNAME);
+            String classpath = fileElement.getAttributeValue(FILE_ATT_CLASSNAME);
 
+            // Iterate over <bugInstance> elements
             for (Element bugInstanceElement : fileElement.getChildElements()) {
-                String type = bugInstanceElement.getAttributeValue(BUGINSTANCE_ATT_TYPE);
-                String priority = bugInstanceElement.getAttributeValue(BUGINSTANCE_ATT_PRIORITY);
-                String category = bugInstanceElement.getAttributeValue(BUGINSTANCE_ATT_CATEGORY);
-                String message = bugInstanceElement.getAttributeValue(BUGINSTANCE_ATT_MESSAGE);
-                Integer line;
-                try {
-                    line = Integer.parseInt(bugInstanceElement.getAttributeValue(BUGINSTANCE_ATT_LINENUMBER));
-                } catch (NumberFormatException e) {
-                    // If for some reason the line number can't be parsed, we default to line 0
-                    line = 0;
-                }
-                issues.add(new Issue(classname, type, priority, category, message, line, null));
+                Issue issue = new Issue(classpath);
+
+                issue.setType(bugInstanceElement.getAttributeValue(BUGINSTANCE_ATT_TYPE));
+                issue.setPriority(bugInstanceElement.getAttributeValue(BUGINSTANCE_ATT_PRIORITY));
+                issue.setCategory(bugInstanceElement.getAttributeValue(BUGINSTANCE_ATT_CATEGORY));
+                issue.setMessage(bugInstanceElement.getAttributeValue(BUGINSTANCE_ATT_MESSAGE));
+
+                issues.add(issue);
             }
         }
         report.setIssues(issues);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
This PR extends the parsing functionality for static code analysis reports.

### Description

- Add XOM for parsing
- Add PMD parsing
- Add Checkstyle parsing
- Switch to parsing of the more verbose spotbugsXml, as it contains a proper source path. Opened an issue to add this information to the xdoc report but this might take a while.
- Rename classname to filePath
- Rename type to rule
- Add PR template

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Build and deploy the notification locally
2. Start Artemis in debug mode and create a programming exercise with static code analysis enabled
3. Set break point in `ResultResource.notifyNewResult`
4. Alter pom.xml in the test repository to include the Checkstyle and Pmd maven plugin (example can be found https://github.com/kloessst/BambooTest/blob/master/pom.xml). Just copy those dependencies.
5. Alter the static code analysis task to match:
![scaTask](https://user-images.githubusercontent.com/16407766/91561927-a55f0980-e93c-11ea-9d9b-492dcdb1d927.PNG)
6. Alter the artifacts to match:
![artifacts](https://user-images.githubusercontent.com/16407766/91561986-ba3b9d00-e93c-11ea-832f-8271a6c2be9e.PNG)
7. Participate in the programming exercise and commit bad code
8. Inspect the request body when the break point triggers
--> Static Code Analysis reports should be part of the request body and should match the format defined in the notification plugin readme.
