### PR TITLE
Add task status to notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,15 +167,31 @@ Sample request
             ],
             "tasks":[
                {
+                  "name":"checkout",
+                  "pluginKey":"com.atlassian.bamboo.plugins.vcs:task.vcs.checkout",
+                  "isEnabled":true,
+                  "isFinal":false,
+                  "status":"SUCCESS"
+               },
+               {
                   "name":"compile",
+                  "pluginKey":"com.atlassian.bamboo.plugins.maven:task.builder.mvn3",
+                  "isEnabled":true,
+                  "isFinal":false,
                   "status":"SUCCESS"
                },
                {
                   "name":"test-compile",
+                  "pluginKey":"com.atlassian.bamboo.plugins.maven:task.builder.mvn3",
+                  "isEnabled":true,
+                  "isFinal":false,
                   "status":"SUCCESS"
                },
                {
                   "name":"tests",
+                  "pluginKey":"com.atlassian.bamboo.plugins.maven:task.builder.mvn3",
+                  "isEnabled":true,
+                  "isFinal":false,
                   "status":"FAILED"
                }           
             ],

--- a/README.md
+++ b/README.md
@@ -171,28 +171,28 @@ Sample request
                   "pluginKey":"com.atlassian.bamboo.plugins.vcs:task.vcs.checkout",
                   "isEnabled":true,
                   "isFinal":false,
-                  "status":"SUCCESS"
+                  "state":"SUCCESS"
                },
                {
                   "description":"compile",
                   "pluginKey":"com.atlassian.bamboo.plugins.maven:task.builder.mvn3",
                   "isEnabled":true,
                   "isFinal":false,
-                  "status":"SUCCESS"
+                  "state":"SUCCESS"
                },
                {
                   "description":"test-compile",
                   "pluginKey":"com.atlassian.bamboo.plugins.maven:task.builder.mvn3",
                   "isEnabled":true,
                   "isFinal":false,
-                  "status":"SUCCESS"
+                  "state":"SUCCESS"
                },
                {
                   "description":"tests",
                   "pluginKey":"com.atlassian.bamboo.plugins.maven:task.builder.mvn3",
                   "isEnabled":true,
                   "isFinal":false,
-                  "status":"FAILED"
+                  "state":"FAILED"
                }           
             ],
             "staticAssessmentReports":[

--- a/README.md
+++ b/README.md
@@ -167,28 +167,28 @@ Sample request
             ],
             "tasks":[
                {
-                  "name":"checkout",
+                  "description":"checkout",
                   "pluginKey":"com.atlassian.bamboo.plugins.vcs:task.vcs.checkout",
                   "isEnabled":true,
                   "isFinal":false,
                   "status":"SUCCESS"
                },
                {
-                  "name":"compile",
+                  "description":"compile",
                   "pluginKey":"com.atlassian.bamboo.plugins.maven:task.builder.mvn3",
                   "isEnabled":true,
                   "isFinal":false,
                   "status":"SUCCESS"
                },
                {
-                  "name":"test-compile",
+                  "description":"test-compile",
                   "pluginKey":"com.atlassian.bamboo.plugins.maven:task.builder.mvn3",
                   "isEnabled":true,
                   "isFinal":false,
                   "status":"SUCCESS"
                },
                {
-                  "name":"tests",
+                  "description":"tests",
                   "pluginKey":"com.atlassian.bamboo.plugins.maven:task.builder.mvn3",
                   "isEnabled":true,
                   "isFinal":false,

--- a/README.md
+++ b/README.md
@@ -165,6 +165,20 @@ Sample request
                   "className":"de.de.ClassTest"
                }
             ],
+            "tasks":[
+               {
+                  "name":"compile",
+                  "status":"SUCCESS"
+               },
+               {
+                  "name":"test-compile",
+                  "status":"SUCCESS"
+               },
+               {
+                  "name":"tests",
+                  "status":"FAILED"
+               }           
+            ],
             "staticAssessmentReports":[
                {
                   "tool":"SPOTBUGS",

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.tum.in.www1</groupId>
     <artifactId>bamboo-server</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <organization>
         <name>LS1 TUM</name>
         <url>http://www1.in.tum.de/</url>

--- a/src/main/java/de/tum/in/www1/bamboo/server/BuildCompleteListener.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/BuildCompleteListener.java
@@ -10,7 +10,9 @@ public class BuildCompleteListener {
     public void onPostBuildComplete(final PostBuildCompletedEvent postBuildCompletedEvent) {
         CurrentBuildResult currentBuildResult = postBuildCompletedEvent.getContext().getBuildResult();
 
-        ResultsContainer resultsContainer = new ResultsContainer(postBuildCompletedEvent.getPlanResultKey(), currentBuildResult.getSuccessfulTestResults(), currentBuildResult.getSkippedTestResults(), currentBuildResult.getFailedTestResults());
+        ResultsContainer resultsContainer = new ResultsContainer(postBuildCompletedEvent.getPlanResultKey(),
+                currentBuildResult.getSuccessfulTestResults(), currentBuildResult.getSkippedTestResults(),
+                currentBuildResult.getFailedTestResults(), currentBuildResult.getTaskResults());
         ServerNotificationRecipient.getCachedTestResults().put(postBuildCompletedEvent.getPlanResultKey().toString(), resultsContainer);
 
         // Remove old ResultsContainer based on their initialization timestamp

--- a/src/main/java/de/tum/in/www1/bamboo/server/BuildCompleteListener.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/BuildCompleteListener.java
@@ -10,10 +10,10 @@ public class BuildCompleteListener {
     public void onPostBuildComplete(final PostBuildCompletedEvent postBuildCompletedEvent) {
         CurrentBuildResult currentBuildResult = postBuildCompletedEvent.getContext().getBuildResult();
 
-        TestResultsContainer testResultsContainer = new TestResultsContainer(postBuildCompletedEvent.getPlanResultKey(), currentBuildResult.getSuccessfulTestResults(), currentBuildResult.getSkippedTestResults(), currentBuildResult.getFailedTestResults());
-        ServerNotificationRecipient.getCachedTestResults().put(postBuildCompletedEvent.getPlanResultKey().toString(), testResultsContainer);
+        ResultsContainer resultsContainer = new ResultsContainer(postBuildCompletedEvent.getPlanResultKey(), currentBuildResult.getSuccessfulTestResults(), currentBuildResult.getSkippedTestResults(), currentBuildResult.getFailedTestResults());
+        ServerNotificationRecipient.getCachedTestResults().put(postBuildCompletedEvent.getPlanResultKey().toString(), resultsContainer);
 
-        // Remove old TestResultsContainer based on their initialization timestamp
+        // Remove old ResultsContainer based on their initialization timestamp
         ServerNotificationRecipient.clearOldTestResultsContainer();
     }
 

--- a/src/main/java/de/tum/in/www1/bamboo/server/ResultsContainer.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ResultsContainer.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-public class TestResultsContainer {
+public class ResultsContainer {
 
     private final PlanResultKey planResultKey;
     private final long initTimestamp = System.currentTimeMillis();
@@ -17,11 +17,11 @@ public class TestResultsContainer {
     private Collection<TestResults> skippedTests = new ArrayList<>();
     private Collection<TestResults> failedTests = new ArrayList<>();
 
-    public TestResultsContainer(PlanResultKey planResultKey) {
+    public ResultsContainer(PlanResultKey planResultKey) {
         this.planResultKey = planResultKey;
     }
 
-    public TestResultsContainer(PlanResultKey planResultKey, Collection<TestResults> successfulTests, Collection<TestResults> skippedTests, Collection<TestResults> failedTests) {
+    public ResultsContainer(PlanResultKey planResultKey, Collection<TestResults> successfulTests, Collection<TestResults> skippedTests, Collection<TestResults> failedTests) {
         this.planResultKey = planResultKey;
         this.successfulTests = successfulTests;
         this.skippedTests = skippedTests;
@@ -50,7 +50,7 @@ public class TestResultsContainer {
 
     @Override
     public String toString() {
-        return "TestResultsContainer{" +
+        return "ResultsContainer{" +
                 "planResultKey=" + planResultKey +
                 ", initTimestamp=" + initTimestamp +
                 ", successfulTests=" + successfulTests +

--- a/src/main/java/de/tum/in/www1/bamboo/server/ResultsContainer.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ResultsContainer.java
@@ -3,6 +3,7 @@ package de.tum.in.www1.bamboo.server;
 import com.atlassian.bamboo.plan.PlanKey;
 import com.atlassian.bamboo.plan.PlanResultKey;
 import com.atlassian.bamboo.results.tests.TestResults;
+import com.atlassian.bamboo.task.TaskResult;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -17,15 +18,19 @@ public class ResultsContainer {
     private Collection<TestResults> skippedTests = new ArrayList<>();
     private Collection<TestResults> failedTests = new ArrayList<>();
 
+    private Collection<TaskResult> taskResults = new ArrayList<>();
+
     public ResultsContainer(PlanResultKey planResultKey) {
         this.planResultKey = planResultKey;
     }
 
-    public ResultsContainer(PlanResultKey planResultKey, Collection<TestResults> successfulTests, Collection<TestResults> skippedTests, Collection<TestResults> failedTests) {
+    public ResultsContainer(PlanResultKey planResultKey, Collection<TestResults> successfulTests, Collection<TestResults> skippedTests,
+                            Collection<TestResults> failedTests, Collection<TaskResult> taskResults) {
         this.planResultKey = planResultKey;
         this.successfulTests = successfulTests;
         this.skippedTests = skippedTests;
         this.failedTests = failedTests;
+        this.taskResults = taskResults;
     }
 
     public PlanResultKey getPlanResultKey() {
@@ -48,6 +53,10 @@ public class ResultsContainer {
         return failedTests;
     }
 
+    public Collection<TaskResult> getTaskResults() {
+        return taskResults;
+    }
+
     @Override
     public String toString() {
         return "ResultsContainer{" +
@@ -56,6 +65,7 @@ public class ResultsContainer {
                 ", successfulTests=" + successfulTests +
                 ", skippedTests=" + skippedTests +
                 ", failedTests=" + failedTests +
+                ", taskResults=" + taskResults +
                 '}';
     }
 }

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationRecipient.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationRecipient.java
@@ -39,7 +39,7 @@ public class ServerNotificationRecipient extends AbstractNotificationRecipient i
     private CustomVariableContext customVariableContext;
     private static BuildLoggerManager buildLoggerManager;
 
-    // Time in seconds before removing TestResultsContainer
+    // Time in seconds before removing ResultsContainer
     private static final int TESTRESULTSCONTAINER_REMOVE_TIME = 60;
 
     /*
@@ -47,12 +47,12 @@ public class ServerNotificationRecipient extends AbstractNotificationRecipient i
      * The TestResults need a BuildContext and can therefor only be accessed when using an Event that extends BuildContextEvent.
      * The normal BuildCompletedEvent does not extend BuildContextEvent, but the PostBuildCompletedEvent does.
      * We listen for the PostBuildCompletedEvent and save the test cases in this Map with the key of the job as String.
-     * The TestResults are stored inside the TestResultsContainer class and it can be retrieved using this Map in the ServerNotificationTransport class.
-     * A method clearOldTestResultsContainer() has been added, that removes old TestResultsContainer from the Map, because we add every build to this Map, even those without
+     * The TestResults are stored inside the ResultsContainer class and it can be retrieved using this Map in the ServerNotificationTransport class.
+     * A method clearOldTestResultsContainer() has been added, that removes old ResultsContainer from the Map, because we add every build to this Map, even those without
      * Notifications enabled.
-     * The time (in seconds) after the TestResultsContainer can be specified in the variable TESTRESULTSCONTAINER_REMOVE_TIME.
+     * The time (in seconds) after the ResultsContainer can be specified in the variable TESTRESULTSCONTAINER_REMOVE_TIME.
      */
-    private static Map<String, TestResultsContainer> cachedTestResults = new ConcurrentHashMap<>();
+    private static Map<String, ResultsContainer> cachedTestResults = new ConcurrentHashMap<>();
 
     @Override
     public void populate(@NotNull Map<String, String[]> params)
@@ -168,7 +168,7 @@ public class ServerNotificationRecipient extends AbstractNotificationRecipient i
         return buildLoggerManager;
     }
 
-    public static Map<String, TestResultsContainer> getCachedTestResults() {
+    public static Map<String, ResultsContainer> getCachedTestResults() {
         return cachedTestResults;
     }
 

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -425,13 +425,14 @@ public class ServerNotificationTransport implements NotificationTransport
      */
     private JSONArray createTasksJSONArray(Collection<TaskResult> taskResults) throws JSONException {
         logToBuildLog("Creating tasks JSON array");
-        JSONArray testResultsArray = new JSONArray();
+        JSONArray tasksArray = new JSONArray();
         for (TaskResult taskResult : taskResults) {
-            JSONObject testResultsJSON = new JSONObject();
-            testResultsJSON.put("name", taskResult.getTaskIdentifier().getUserDescription());
-            testResultsJSON.put("state", taskResult.getTaskState().toString());
+            JSONObject taskJSON = new JSONObject();
+            taskJSON.put("name", taskResult.getTaskIdentifier().getUserDescription());
+            taskJSON.put("state", taskResult.getTaskState().toString());
+            tasksArray.put(taskJSON);
         }
-        return testResultsArray;
+        return tasksArray;
     }
 
     private void logToBuildLog(String s) {

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -417,7 +417,8 @@ public class ServerNotificationTransport implements NotificationTransport
     }
 
     /**
-     * Creates an JSONArray containing task names and their state (Success, Failed, Error)
+     * Creates an JSONArray containing task name, plugin key, whether the task is final or enabled and the
+     * state (SUCCESS, FAILED, ERROR) for each defined task.
      *
      * @param taskResults Collection of all defined tasks with details
      * @return JSONArray containing the name and state
@@ -429,6 +430,9 @@ public class ServerNotificationTransport implements NotificationTransport
         for (TaskResult taskResult : taskResults) {
             JSONObject taskJSON = new JSONObject();
             taskJSON.put("name", taskResult.getTaskIdentifier().getUserDescription());
+            taskJSON.put("pluginKey", taskResult.getTaskIdentifier().getPluginKey());
+            taskJSON.put("isEnabled", taskResult.getTaskIdentifier().isEnabled());
+            taskJSON.put("isFinal", taskResult.getTaskIdentifier().isFinalising());
             taskJSON.put("state", taskResult.getTaskState().name());
             tasksArray.put(taskJSON);
         }

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -429,7 +429,7 @@ public class ServerNotificationTransport implements NotificationTransport
         JSONArray tasksArray = new JSONArray();
         for (TaskResult taskResult : taskResults) {
             JSONObject taskJSON = new JSONObject();
-            taskJSON.put("name", taskResult.getTaskIdentifier().getUserDescription());
+            taskJSON.put("description", taskResult.getTaskIdentifier().getUserDescription());
             taskJSON.put("pluginKey", taskResult.getTaskIdentifier().getPluginKey());
             taskJSON.put("isEnabled", taskResult.getTaskIdentifier().isEnabled());
             taskJSON.put("isFinal", taskResult.getTaskIdentifier().isFinalising());

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -429,7 +429,7 @@ public class ServerNotificationTransport implements NotificationTransport
         for (TaskResult taskResult : taskResults) {
             JSONObject taskJSON = new JSONObject();
             taskJSON.put("name", taskResult.getTaskIdentifier().getUserDescription());
-            taskJSON.put("state", taskResult.getTaskState().toString());
+            taskJSON.put("state", taskResult.getTaskState().name());
             tasksArray.put(taskJSON);
         }
         return tasksArray;

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -50,7 +50,6 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -276,16 +275,16 @@ public class ServerNotificationTransport implements NotificationTransport
                             jobDetails.put("id", buildResultsSummary.getId());
 
                             logToBuildLog("Loading cached test results for job " + buildResultsSummary.getId());
-                            TestResultsContainer testResultsContainer = ServerNotificationRecipient.getCachedTestResults().get(buildResultsSummary.getPlanResultKey().toString());
-                            if (testResultsContainer != null) {
+                            ResultsContainer resultsContainer = ServerNotificationRecipient.getCachedTestResults().get(buildResultsSummary.getPlanResultKey().toString());
+                            if (resultsContainer != null) {
                                 logToBuildLog("Tests results found");
-                                JSONArray successfulTestDetails = createTestsResultsJSONArray(testResultsContainer.getSuccessfulTests(), false);
+                                JSONArray successfulTestDetails = createTestsResultsJSONArray(resultsContainer.getSuccessfulTests(), false);
                                 jobDetails.put("successfulTests", successfulTestDetails);
 
-                                JSONArray skippedTestDetails = createTestsResultsJSONArray(testResultsContainer.getSkippedTests(), false);
+                                JSONArray skippedTestDetails = createTestsResultsJSONArray(resultsContainer.getSkippedTests(), false);
                                 jobDetails.put("skippedTests", skippedTestDetails);
 
-                                JSONArray failedTestDetails = createTestsResultsJSONArray(testResultsContainer.getFailedTests(), true);
+                                JSONArray failedTestDetails = createTestsResultsJSONArray(resultsContainer.getFailedTests(), true);
                                 jobDetails.put("failedTests", failedTestDetails);
                             } else {
                                 logErrorToBuildLog("Could not load cached test results!");

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -20,6 +20,7 @@ import com.atlassian.bamboo.resultsummary.ResultsSummary;
 import com.atlassian.bamboo.resultsummary.tests.TestCaseResultError;
 import com.atlassian.bamboo.resultsummary.tests.TestResultsSummary;
 import com.atlassian.bamboo.resultsummary.vcs.RepositoryChangeset;
+import com.atlassian.bamboo.task.TaskResult;
 import com.atlassian.bamboo.utils.HttpUtils;
 import com.atlassian.bamboo.variable.CustomVariableContext;
 import com.atlassian.bamboo.variable.VariableDefinition;
@@ -286,6 +287,9 @@ public class ServerNotificationTransport implements NotificationTransport
 
                                 JSONArray failedTestDetails = createTestsResultsJSONArray(resultsContainer.getFailedTests(), true);
                                 jobDetails.put("failedTests", failedTestDetails);
+
+                                JSONArray taskResults = createTaskResultsJSONArray(resultsContainer.getTaskResults());
+                                jobDetails.put("tasks", taskResults);
                             } else {
                                 logErrorToBuildLog("Could not load cached test results!");
                             }
@@ -409,6 +413,24 @@ public class ServerNotificationTransport implements NotificationTransport
             testResultsArray.put(createTestsResultsJSONObject(testResults, addErrors));
         }
 
+        return testResultsArray;
+    }
+
+    /**
+     * Creates an JSONArray containing task names and their state (Success, Failed, Error)
+     *
+     * @param taskResults Collection of all defined tasks with details
+     * @return JSONArray containing the name and state
+     * @throws JSONException
+     */
+    private JSONArray createTaskResultsJSONArray(Collection<TaskResult> taskResults) throws JSONException {
+        logToBuildLog("Creating tasks JSON array");
+        JSONArray testResultsArray = new JSONArray();
+        for (TaskResult taskResult : taskResults) {
+            JSONObject testResultsJSON = new JSONObject();
+            testResultsJSON.put("name", taskResult.getTaskIdentifier().getUserDescription());
+            testResultsJSON.put("state", taskResult.getTaskState().toString());
+        }
         return testResultsArray;
     }
 

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -288,7 +288,7 @@ public class ServerNotificationTransport implements NotificationTransport
                                 JSONArray failedTestDetails = createTestsResultsJSONArray(resultsContainer.getFailedTests(), true);
                                 jobDetails.put("failedTests", failedTestDetails);
 
-                                JSONArray taskResults = createTaskResultsJSONArray(resultsContainer.getTaskResults());
+                                JSONArray taskResults = createTasksJSONArray(resultsContainer.getTaskResults());
                                 jobDetails.put("tasks", taskResults);
                             } else {
                                 logErrorToBuildLog("Could not load cached test results!");
@@ -423,7 +423,7 @@ public class ServerNotificationTransport implements NotificationTransport
      * @return JSONArray containing the name and state
      * @throws JSONException
      */
-    private JSONArray createTaskResultsJSONArray(Collection<TaskResult> taskResults) throws JSONException {
+    private JSONArray createTasksJSONArray(Collection<TaskResult> taskResults) throws JSONException {
         logToBuildLog("Creating tasks JSON array");
         JSONArray testResultsArray = new JSONArray();
         for (TaskResult taskResult : taskResults) {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently there is no way to distinguish if the student code failed to compile or the test code.

### Description
- Added tasks array to notification containing the task name and its status

![Capture](https://user-images.githubusercontent.com/16407766/91194807-c8997700-e6f8-11ea-86b8-e6712e3af094.PNG)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Deploy the notification plugin locally
2. Start Artemis in debug mode and set break point at `ResultResource.notifyNewProgrammingExerciseResult`
3. Create a programming exercise
4. Commit something
5. Break point should trigger
--> Check that the tasks are contained within notification payload
6. Provoke a build error
--> Check that the task status is reasonable in the notification payload
