### PR TITLE
Update static code analysis parser & make ReportParser local

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.tum.in.www1</groupId>
     <artifactId>bamboo-server</artifactId>
-    <version>1.3.4</version>
+    <version>1.3.5</version>
     <organization>
         <name>LS1 TUM</name>
         <url>https://ase.in.tum.de</url>
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>de.tum.in.ase</groupId>
             <artifactId>static-code-analysis-parser</artifactId>
-            <version>1.3.2</version>
+            <version>1.3.3</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -75,8 +75,6 @@ public class ServerNotificationTransport implements NotificationTransport {
 
     private CloseableHttpClient client;
 
-    private ReportParser reportParser;
-
     @Nullable
     private final ImmutablePlan plan;
 
@@ -118,7 +116,6 @@ public class ServerNotificationTransport implements NotificationTransport {
         this.resultsSummary = resultsSummary;
         this.deploymentResult = deploymentResult;
         this.buildLoggerManager = buildLoggerManager;
-        this.reportParser = new ReportParser();
         this.buildLogFileAccessorFactory = buildLogFileAccessorFactory;
 
         URI uri;
@@ -374,6 +371,8 @@ public class ServerNotificationTransport implements NotificationTransport {
         try {
             logToBuildLog("Creating artifact JSON object for artifact definition: " + label);
             // The report parser is able to identify the tool to which the report belongs
+            ReportParser reportParser = new ReportParser();
+
             String reportJSON = reportParser.transformToJSONReport(rootFile);
             return Optional.of(new JSONObject(reportJSON));
         }


### PR DESCRIPTION
<!-- Thanks for contributing to the Bamboo Server Notification Plugin! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I built and deployed the plugin locally and tested *all* changes and *all* related features.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
This PR is part of https://github.com/ls1intum/static-code-analysis-parser/pull/6 which should be merged before this PR.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The static code analysis parser has been updated to address issues that occur when the code analysis reports are too big. The plugin must therefore be updated to incorporate the changes.

### Description
<!-- Describe your changes in detail -->
This PR updates the static code analysis parser and removes the global `ReportParser` object from the plugin. Instead, it's used locally in order to allow the garbage collector to clean up after use.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Deploy the plugin on a local Bamboo installation
2. Generate a Programming Exercise with static code analysis enabled
3. Participate in the exercise
3. Modify the build plan of the participation and add a new script task generates a fake static code analysis report that is over 1MB (see screenshot)
4. If you submit the code, you should get a static code analysis issue stating that there are too many issues


![image](https://user-images.githubusercontent.com/11298674/123406091-d5058f00-d5aa-11eb-85b2-9e40659451f9.png)
