### PR TITLE
`Feature`: Include testwise coverage reports into notification payload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
                 <version>${spotless.version}</version>
                 <configuration>
                     <!-- limit format enforcement to just the files changed by this feature branch -->
-                    <ratchetFrom>origin/master</ratchetFrom>
+                    <ratchetFrom>origin/main</ratchetFrom>
                     <!-- define a language-specific format -->
                     <java>
                         <!-- These are the defaults, you can override if you want -->

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -429,7 +429,8 @@ public class ServerNotificationTransport implements NotificationTransport {
         catch (IOException exception) {
             LoggingUtils.logInfo("Could not read from artifact file for " + artifact.getLabel() + " in job " + jobId, buildLoggerManager, plan != null ? plan.getPlanKey() : null,
                     log);
-        } catch (JSONException exception) {
+        }
+        catch (JSONException exception) {
             LoggingUtils.logInfo("Could not read parse Testwise Coverage Report for in job " + jobId, buildLoggerManager, plan != null ? plan.getPlanKey() : null,
                     log);
             LoggingUtils.logInfo(exception.getMessage(), buildLoggerManager, plan != null ? plan.getPlanKey() : null, log);

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -9,9 +9,13 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-import com.google.gson.Gson;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.StatusLine;
@@ -61,6 +65,7 @@ import com.atlassian.bamboo.variable.VariableDefinition;
 import com.atlassian.bamboo.variable.VariableDefinitionManager;
 import com.atlassian.spring.container.ContainerManager;
 import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
 
 import de.tum.in.ase.parser.ReportParser;
 import de.tum.in.ase.parser.exception.ParserException;
@@ -376,11 +381,13 @@ public class ServerNotificationTransport implements NotificationTransport {
             return Optional.of(new JSONObject(reportJSON));
         }
         catch (JSONException e) {
-            LoggingUtils.logError("Error constructing artifact JSON for artifact definition " + label + ": " + e.getMessage(), buildLoggerManager, plan != null ? plan.getPlanKey() : null, log, e);
+            LoggingUtils.logError("Error constructing artifact JSON for artifact definition " + label + ": " + e.getMessage(), buildLoggerManager,
+                    plan != null ? plan.getPlanKey() : null, log, e);
 
         }
         catch (ParserException e) {
-            LoggingUtils.logError("Error parsing static code analysis report " + label + ": " + e.getMessage(), buildLoggerManager, plan != null ? plan.getPlanKey() : null, log, e);
+            LoggingUtils.logError("Error parsing static code analysis report " + label + ": " + e.getMessage(), buildLoggerManager, plan != null ? plan.getPlanKey() : null, log,
+                    e);
         }
         return Optional.empty();
     }
@@ -402,8 +409,10 @@ public class ServerNotificationTransport implements NotificationTransport {
         ArtifactLinkDataProvider dataProvider = artifactLinkManager.getArtifactLinkDataProvider(artifact);
 
         if (dataProvider == null) {
-            LoggingUtils.logInfo("ArtifactLinkDataProvider is null for " + artifact.getLabel() + " in job " + jobId, buildLoggerManager, plan != null ? plan.getPlanKey() : null, log);
-            LoggingUtils.logInfo("Could not retrieve data for artifact " + artifact.getLabel() + " in job " + jobId, buildLoggerManager, plan != null ? plan.getPlanKey() : null, log);
+            LoggingUtils.logInfo("ArtifactLinkDataProvider is null for " + artifact.getLabel() + " in job " + jobId, buildLoggerManager, plan != null ? plan.getPlanKey() : null,
+                    log);
+            LoggingUtils.logInfo("Could not retrieve data for artifact " + artifact.getLabel() + " in job " + jobId, buildLoggerManager, plan != null ? plan.getPlanKey() : null,
+                    log);
             return null;
         }
 
@@ -416,8 +425,10 @@ public class ServerNotificationTransport implements NotificationTransport {
                 Gson gson = new Gson();
                 return new JSONObject(gson.fromJson(reader, Map.class)).getJSONArray("tests");
             }
-        } catch (IOException exception) {
-            LoggingUtils.logInfo("Could not read from artifact file for " + artifact.getLabel() + " in job " + jobId, buildLoggerManager, plan != null ? plan.getPlanKey() : null, log);
+        }
+        catch (IOException exception) {
+            LoggingUtils.logInfo("Could not read from artifact file for " + artifact.getLabel() + " in job " + jobId, buildLoggerManager, plan != null ? plan.getPlanKey() : null,
+                    log);
         }
         return null;
     }
@@ -437,8 +448,10 @@ public class ServerNotificationTransport implements NotificationTransport {
             ArtifactLinkDataProvider dataProvider = artifactLinkManager.getArtifactLinkDataProvider(artifact);
 
             if (dataProvider == null) {
-                LoggingUtils.logInfo("ArtifactLinkDataProvider is null for " + artifact.getLabel() + " in job " + jobId, buildLoggerManager, plan != null ? plan.getPlanKey() : null, log);
-                LoggingUtils.logInfo("Could not retrieve data for artifact " + artifact.getLabel() + " in job " + jobId, buildLoggerManager, plan != null ? plan.getPlanKey() : null, log);
+                LoggingUtils.logInfo("ArtifactLinkDataProvider is null for " + artifact.getLabel() + " in job " + jobId, buildLoggerManager,
+                        plan != null ? plan.getPlanKey() : null, log);
+                LoggingUtils.logInfo("Could not retrieve data for artifact " + artifact.getLabel() + " in job " + jobId, buildLoggerManager,
+                        plan != null ? plan.getPlanKey() : null, log);
                 continue;
             }
 

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -311,9 +311,9 @@ public class ServerNotificationTransport implements NotificationTransport {
                                     LoggingUtils.logError("Error during parsing static code analysis reports :" + e.getMessage(), buildLoggerManager, plan.getPlanKey(), log, e);
                                 }
                                 try {
-                                    JSONArray testwiseCoverageReports = createTestwiseCoverageJSONObject(artifactLinks, buildResultsSummary.getId());
-                                    if (testwiseCoverageReports != null) {
-                                        jobDetails.put("testwiseCoverageReport", testwiseCoverageReports);
+                                    JSONArray testwiseCoverageReport = createTestwiseCoverageJSONObject(artifactLinks, buildResultsSummary.getId());
+                                    if (testwiseCoverageReport != null) {
+                                        jobDetails.put("testwiseCoverageReport", testwiseCoverageReport);
                                     }
                                 }
                                 catch (Exception e) {

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -429,6 +429,10 @@ public class ServerNotificationTransport implements NotificationTransport {
         catch (IOException exception) {
             LoggingUtils.logInfo("Could not read from artifact file for " + artifact.getLabel() + " in job " + jobId, buildLoggerManager, plan != null ? plan.getPlanKey() : null,
                     log);
+        } catch (JSONException exception) {
+            LoggingUtils.logInfo("Could not read parse Testwise Coverage Report for in job " + jobId, buildLoggerManager, plan != null ? plan.getPlanKey() : null,
+                    log);
+            LoggingUtils.logInfo(exception.getMessage(), buildLoggerManager, plan != null ? plan.getPlanKey() : null, log);
         }
         return null;
     }

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -325,8 +325,7 @@ public class ServerNotificationTransport implements NotificationTransport {
                                     LoggingUtils.logError("Error during parsing static code analysis reports :" + e.getMessage(), buildLoggerManager, plan.getPlanKey(), log, e);
                                 }
                                 try {
-                                    JSONArray testwiseCoverageReports = createTestwiseCoverageJSONObject(buildResultsSummary.getProducedArtifactLinks(),
-                                            buildResultsSummary.getId());
+                                    JSONArray testwiseCoverageReports = createTestwiseCoverageJSONObject(artifactLinks, buildResultsSummary.getId());
                                     if (testwiseCoverageReports != null) {
                                         jobDetails.put("testwiseCoverageReport", testwiseCoverageReports);
                                     }

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -1,21 +1,18 @@
 package de.tum.in.www1.bamboo.server;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.StatusLine;
@@ -64,7 +61,6 @@ import com.atlassian.bamboo.variable.VariableDefinition;
 import com.atlassian.bamboo.variable.VariableDefinitionManager;
 import com.atlassian.spring.container.ContainerManager;
 import com.google.common.collect.ImmutableList;
-import com.google.gson.Gson;
 
 import de.tum.in.ase.parser.ReportParser;
 import de.tum.in.ase.parser.exception.ParserException;
@@ -426,10 +422,9 @@ public class ServerNotificationTransport implements NotificationTransport {
             if (dataProvider instanceof FileSystemArtifactLinkDataProvider) {
                 FileSystemArtifactLinkDataProvider fileDataProvider = (FileSystemArtifactLinkDataProvider) dataProvider;
                 File artifactFile = fileDataProvider.getFile();
-                BufferedReader reader = Files.newBufferedReader(artifactFile.toPath());
-
-                Gson gson = new Gson();
-                return new JSONObject(gson.fromJson(reader, Map.class)).getJSONArray("tests");
+                InputStream inputStream = new FileInputStream(artifactFile.getAbsolutePath());
+                String fileContent = IOUtils.toString(inputStream, "UTF-8");
+                return new JSONObject(fileContent).getJSONArray("tests");
             }
         }
         catch (IOException exception) {

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -317,7 +317,7 @@ public class ServerNotificationTransport implements NotificationTransport {
                                     }
                                 }
                                 catch (Exception e) {
-                                    LoggingUtils.logError("Error during parsing testwise coverage reports :" + e.getMessage(), buildLoggerManager, plan.getPlanKey(), log, e);
+                                    LoggingUtils.logError("Error during parsing testwise coverage report :" + e.getMessage(), buildLoggerManager, plan.getPlanKey(), log, e);
                                 }
                             }
                             catch (Exception ex) {
@@ -401,7 +401,7 @@ public class ServerNotificationTransport implements NotificationTransport {
      * @return a JSONArray containing all testwise coverage reports if this artifact exists, otherwise null
      */
     private JSONArray createTestwiseCoverageJSONObject(Collection<ArtifactLink> artifactLinks, long jobId) {
-        Optional<ArtifactLink> optionalArtifactLink = artifactLinks.stream().filter(artifact -> "coverageResults".equals(artifact.getArtifact().getLabel())).findFirst();
+        Optional<ArtifactLink> optionalArtifactLink = artifactLinks.stream().filter(artifact -> "testwiseCoverageReport".equals(artifact.getArtifact().getLabel())).findFirst();
 
         if (!optionalArtifactLink.isPresent()) {
             return null;


### PR DESCRIPTION
### Checklist
- [x] I built and deployed the plugin locally and tested *all* changes and *all* related features.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
As part of the Bachelor Thesis from @Hialus and @ole-ve about the automatic generation of code hints for programming exercises (HESTIA) in Java, testwise coverage has to be recorded. This is done within the SOLUTION build plan created by Artemis and executed on Bamboo.
In order for Artemis to receive this coverage data, the notification payload has to be extended to include this data.

### Description
The coverage data can be obtained from the artifact 'coverageReports' (this is an arbitrary but fixed name) and the file is already in the JSON-format. Within these changes, the plugin checks after the build has completed if this artifact exists. If this is the case, it will be parsed to a JSONArray and added to the `jobs` in the notification payload. Other than that, nothing has been changed.
The relevant part of the changes look as following:
```json
"jobs": [
      {
        "skippedTests": [
            // unchanged
        ],
        "failedTests": [
            // unchanged
        ],
        "successfulTests": [
            // unchanged
        ],
        "tasks": [
            // unchanged
        ],
        "staticCodeAnalysisReports": [
            // unchange
        ],
        "testwiseCoverageReport": [
          {
            "duration": 0.036,
            "paths": [
              {
                "files": [
                  {
                    "coveredLines": "6",
                    "fileName": "BubbleSort.java"
                  },
                  {
                    "coveredLines": "6,12,16-17,20-21,24",
                    "fileName": "Context.java"
                  },
                  {
                    "coveredLines": "9-11,17,21-22,24",
                    "fileName": "Policy.java"
                  }
                ],
                "path": "de/tum/in/ase"
              }
            ],
            "result": "PASSED",
            "sourcePath": "de/tum/in/ase/SortingExampleBehaviorTest",
            "uniformPath": "de/tum/in/ase/SortingExampleBehaviorTest/testUseBubbleSortForSmallList()"
          },
          {
            "duration": 0.027,
            "paths": [
              {
                "files": [
                  {
                    "coveredLines": "6,12,16-17,20-21,24",
                    "fileName": "Context.java"
                  },
                  {
                    "coveredLines": "6",
                    "fileName": "MergeSort.java"
                  },
                  {
                    "coveredLines": "9-11,17-19,24",
                    "fileName": "Policy.java"
                  }
                ],
                "path": "de/tum/in/ase"
              }
            ],
            "result": "PASSED",
            "sourcePath": "de/tum/in/ase/SortingExampleBehaviorTest",
            "uniformPath": "de/tum/in/ase/SortingExampleBehaviorTest/testUseMergeSortForBigList()"
          }
        ],
        "logs": [
           // unchanged
        ],
        "id": 14581874
      }
    ],
```

### Steps for Testing
1. Deploy the plugin on a local Bamboo installation
2. Start the build plan. Once it is finished, check that the results have been sent correctly to Artemis (Test results and SCA reports).
3. Upload a .json-file to the test repository where it will not be deleted on 'clean' (so target and build would be invalid). This simulates the creation of the coverage data, which is not part of this PR. You can use [this file](https://drive.google.com/file/d/1iH26Zb5Ko2EESIxcIhI6jnd9PaECVpt7/view?usp=sharing) as an exemplary coverage result file.
4. Create an artifact with 'testwiseCoverageReport'. This artifact points to the file the .json-file has been saved in the previous step.
5. Start the build plan. Once it is finished, check in the Artemis-Server console that the notification sent contains the data from the .json-file.
