### PR TITLE
Ignore empty report files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.tum.in.www1</groupId>
     <artifactId>bamboo-server</artifactId>
-    <version>1.5.2</version>
+    <version>1.5.3</version>
     <organization>
         <name>LS1 TUM</name>
         <url>https://ase.in.tum.de</url>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.tum.in.www1</groupId>
     <artifactId>bamboo-server</artifactId>
-    <version>1.5.1</version>
+    <version>1.5.2</version>
     <organization>
         <name>LS1 TUM</name>
         <url>https://ase.in.tum.de</url>

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -372,6 +372,7 @@ public class ServerNotificationTransport implements NotificationTransport {
         /*
          * The rootFile is a directory if the copy pattern matches multiple files, otherwise it is a regular file.
          * Ignore artifact definitions matching multiple files.
+         * Also, ignore empty (0-byte) files since they cause parsing errors since they are invalid XML.
          */
         // TODO: Support artifact definitions matching multiple files
         if (rootFile == null || rootFile.length() == 0 || rootFile.isDirectory()) {

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -370,7 +370,7 @@ public class ServerNotificationTransport implements NotificationTransport {
          * Ignore artifact definitions matching multiple files.
          */
         // TODO: Support artifact definitions matching multiple files
-        if (rootFile == null || rootFile.isDirectory()) {
+        if (rootFile == null || rootFile.length() == 0 || rootFile.isDirectory()) {
             return Optional.empty();
         }
 


### PR DESCRIPTION
### Checklist
- [x] I built and deployed the plugin locally and tested *all* changes and *all* related features.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
Currently, when a submission in a programming exercise with SCA contains build errors, checkstyle generates an empty (0 byte) `checkstyle-result.xml`-file.
Parsing this file then fails (as it is not valid xml), which is then reported to Artemis as `feedback`.
This causes the k6-tests to fail, as they expect no feedback for a failing build (Jenkins fulfills this property and Bamboo used to).

### Description
Ignore 0-length xml-files from parser.

### Steps for Testing
1. Deploy the plugin on a local Bamboo installation
2. Generate an exercise with SCA enabled.
3. Cause a build failure
4. Check the corresponding `result`: It should have `hasFeedback` set to false


The updated version is already deployed on Bamboo Prelive and the k6 tests pass again: https://bamboo.ase.in.tum.de/browse/ARTEMIS-SATS-EXAMJ-719