### PR TITLE
Fix usage of styled log entries

### DIFF
--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -556,13 +556,13 @@ public class ServerNotificationTransport implements NotificationTransport {
 
     private JSONObject createLogEntryJSONObject(LogEntry logEntry) throws JSONException {
         JSONObject logEntryObject = new JSONObject();
-		// Note: The following code is duplicated into Artemis: BambooService:retrieveLatestBuildLogsFromBamboo
-	    String logString = logEntry.getUnstyledLog();
-	    // The log is provided in two attributes: with unescaped characters in unstyledLog and with escaped characters in log
-	    // We want to have unescaped characters but fall back to the escaped characters in case no unescaped characters are present
-	    if (logString == null) {
-		    logString = logEntry.getLog();
-	    }
+        // Note: The following code is duplicated into Artemis: BambooService:retrieveLatestBuildLogsFromBamboo
+        String logString = logEntry.getUnstyledLog();
+        // The log is provided in two attributes: with unescaped characters in unstyledLog and with escaped characters in log
+        // We want to have unescaped characters but fall back to the escaped characters in case no unescaped characters are present
+        if (logString == null) {
+            logString = logEntry.getLog();
+        }
         logEntryObject.put("log", logString);
         logEntryObject.put("date", ZonedDateTime.ofInstant(logEntry.getDate().toInstant(), ZoneId.systemDefault()));
 

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -556,7 +556,14 @@ public class ServerNotificationTransport implements NotificationTransport {
 
     private JSONObject createLogEntryJSONObject(LogEntry logEntry) throws JSONException {
         JSONObject logEntryObject = new JSONObject();
-        logEntryObject.put("log", logEntry.getLog());
+		// Note: The following code is duplicated into Artemis: BambooService:retrieveLatestBuildLogsFromBamboo
+	    String logString = logEntry.getUnstyledLog();
+	    // The log is provided in two attributes: with unescaped characters in unstyledLog and with escaped characters in log
+	    // We want to have unescaped characters but fall back to the escaped characters in case no unescaped characters are present
+	    if (logString == null) {
+		    logString = logEntry.getLog();
+	    }
+        logEntryObject.put("log", logString);
         logEntryObject.put("date", ZonedDateTime.ofInstant(logEntry.getDate().toInstant(), ZoneId.systemDefault()));
 
         return logEntryObject;


### PR DESCRIPTION
### Checklist
- [x] I built and deployed the plugin locally and tested *all* changes and *all* related features.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
While working on https://github.com/ls1intum/Artemis/pull/5867 I noticed that some logs contained HTML styling elements like `<div>` that should not be there. 

![grafik](https://user-images.githubusercontent.com/26540346/203800799-04d494ff-04c4-4933-9de5-bc612685c7a5.png)


### Description
This PR removes such elements by using unstyled logs instead of styled logs. I also added a duplication warning.

### Steps for Testing

1. Deploy the plugin on a local Bamboo installation
2. Create a build failure so that you can see the logs on Artemis
3. Check that no style-tags are there
