### PR TITLE
Fix too early truncate of feedbacks

### DIFF
--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -88,7 +88,7 @@ public class ServerNotificationTransport implements NotificationTransport {
     private final ArtifactLinkManager artifactLinkManager = (ArtifactLinkManager) ContainerManager.getComponent("artifactLinkManager");
 
     // Maximum length for the feedback text. The feedback will be truncated afterwards
-    private static final int LONG_FEEDBACK_MAX_LENGTH = 10_000_000;
+    private static final int FEEDBACK_MAX_LENGTH = 10_000;
 
     // Maximum number of lines of log per job. The last lines will be taken.
     private static final int JOB_LOG_MAX_LINES = 5000;
@@ -510,8 +510,8 @@ public class ServerNotificationTransport implements NotificationTransport {
             JSONArray testCaseErrorDetails = new JSONArray();
             for (TestCaseResultError testCaseResultError : testResults.getErrors()) {
                 String errorMessageString = testCaseResultError.getContent();
-                if (errorMessageString != null && errorMessageString.length() > LONG_FEEDBACK_MAX_LENGTH) {
-                    errorMessageString = errorMessageString.substring(0, LONG_FEEDBACK_MAX_LENGTH);
+                if (errorMessageString != null && errorMessageString.length() > FEEDBACK_MAX_LENGTH) {
+                    errorMessageString = errorMessageString.substring(0, FEEDBACK_MAX_LENGTH);
                 }
                 testCaseErrorDetails.put(errorMessageString);
             }

--- a/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
+++ b/src/main/java/de/tum/in/www1/bamboo/server/ServerNotificationTransport.java
@@ -88,7 +88,7 @@ public class ServerNotificationTransport implements NotificationTransport {
     private final ArtifactLinkManager artifactLinkManager = (ArtifactLinkManager) ContainerManager.getComponent("artifactLinkManager");
 
     // Maximum length for the feedback text. The feedback will be truncated afterwards
-    private static final int FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS = 5000;
+    private static final int LONG_FEEDBACK_MAX_LENGTH = 10_000_000;
 
     // Maximum number of lines of log per job. The last lines will be taken.
     private static final int JOB_LOG_MAX_LINES = 5000;
@@ -510,8 +510,8 @@ public class ServerNotificationTransport implements NotificationTransport {
             JSONArray testCaseErrorDetails = new JSONArray();
             for (TestCaseResultError testCaseResultError : testResults.getErrors()) {
                 String errorMessageString = testCaseResultError.getContent();
-                if (errorMessageString != null && errorMessageString.length() > FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS) {
-                    errorMessageString = errorMessageString.substring(0, FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS);
+                if (errorMessageString != null && errorMessageString.length() > LONG_FEEDBACK_MAX_LENGTH) {
+                    errorMessageString = errorMessageString.substring(0, LONG_FEEDBACK_MAX_LENGTH);
                 }
                 testCaseErrorDetails.put(errorMessageString);
             }


### PR DESCRIPTION
### Checklist
- [ ] I built and deployed the plugin locally and tested *all* changes and *all* related features.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
Artemis now supports long feedback, so we don't need to cut Feedback in the bamboo plugin.

### Description
I changed the maxium feedback length to the hard limit of long feedback in Artemis.

### Steps for Testing
see https://github.com/ls1intum/Artemis/pull/6856
